### PR TITLE
Add text highlighting and renderGraph functions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,16 @@
 
 1. Visit [chrome://extensions/](chrome://extensions/) and toggle developper mode ON
 2. Click on ```Load unpacked``` and select the WikiExtension folder
+
+### How to do highlighting
+
+Highlighting needs to be given raw content (text, including bolding and links). See the example from the Carleton page. 
+
+```javascript
+const persistent = ['ranked #1 in Undergraduate Teaching by U.S. News & World Report for over a decade', 'Founded in 1866', 
+                    'Admissions is highly selective', 'Carleton is one of the highest sources of undergraduate students pursuing doctorates'];
+var arrayLength = persistent.length;
+for (var i = 0; i < arrayLength; i++) {
+    highlightPersistentContent(persistent[i], '#99FF84');
+}
+```

--- a/WikiExtension/manifest.json
+++ b/WikiExtension/manifest.json
@@ -13,7 +13,7 @@
 	"icons": {
 		"16": "assets/wikiIcon16.png"
 	},
-	"permission": [
+	"permissions": [
 		"storage",
 		"tabs"
 	],

--- a/WikiExtension/src/content.js
+++ b/WikiExtension/src/content.js
@@ -1,0 +1,38 @@
+/* Creates the div for the graph overlay. TODO: create the graph */
+function renderGraphOverlay() {
+    let graphContainer = document.createElement('div');
+    graphContainer.style.cssText = 'width:50%;height:150px;background-color:#E3C2FF;';
+
+    let p = document.createElement('p');
+    graphContainer.appendChild(p);
+    let text = document.createTextNode('The graph overlay will be here');
+    p.appendChild(text);
+
+    let bodyContent = document.getElementById('bodyContent');
+    bodyContent.insertBefore(graphContainer, bodyContent.firstChild);
+}
+
+/* Highlights the words that are given */
+function highlightPersistentContent(text, color) {
+    let wikiText = document.getElementById('mw-content-text');
+    let innerHTML = wikiText.innerHTML;
+    let index = innerHTML.indexOf(text);
+    if (index >= 0) { 
+        innerHTML = innerHTML.substring(0,index) + `<mark style='background-color: ${color}'>` + innerHTML.substring(index, index + text.length) + '</mark>' + innerHTML.substring(index + text.length);
+        wikiText.innerHTML = innerHTML;
+    }
+}
+
+// Highlight the entire (content) text of a Wikipedia page. Why? Testing
+let wikiContent = document.getElementById('mw-content-text');
+wikiContent.style.backgroundColor = '#CDE8FF';
+
+renderGraphOverlay();
+
+// Edge case: note how it didn't highlight the links
+const persistent = ['ranked #1 in Undergraduate Teaching by U.S. News & World Report for over a decade', 'Founded in 1866', 
+                    'Admissions is highly selective', 'Carleton is one of the highest sources of undergraduate students pursuing doctorates'];
+var arrayLength = persistent.length;
+for (var i = 0; i < arrayLength; i++) {
+    highlightPersistentContent(persistent[i], '#99FF84');
+}

--- a/WikiExtension/src/content.js
+++ b/WikiExtension/src/content.js
@@ -1,38 +1,28 @@
-/* Creates the div for the graph overlay. TODO: create the graph */
+/* Creates the div for the graph overlay. TODO: create the graph and render it here */
 function renderGraphOverlay() {
     let graphContainer = document.createElement('div');
-    graphContainer.style.cssText = 'width:50%;height:150px;background-color:#E3C2FF;';
+    graphContainer.style.cssText = 'width:40%;height:180px;background-color:#E3C2FF;';
 
     let p = document.createElement('p');
     graphContainer.appendChild(p);
     let text = document.createTextNode('The graph overlay will be here');
     p.appendChild(text);
 
-    let bodyContent = document.getElementById('bodyContent');
-    bodyContent.insertBefore(graphContainer, bodyContent.firstChild);
+    let siteSub = document.getElementById('siteSub');
+    siteSub.append(graphContainer);
 }
+
+// Get wikipedia text, global as we shouldn't get it every time we highlight a word 
+let wikiText = document.getElementById('mw-content-text');
+let innerHTML = wikiText.innerHTML;
 
 /* Highlights the words that are given */
 function highlightPersistentContent(text, color) {
-    let wikiText = document.getElementById('mw-content-text');
-    let innerHTML = wikiText.innerHTML;
     let index = innerHTML.indexOf(text);
     if (index >= 0) { 
-        innerHTML = innerHTML.substring(0,index) + `<mark style='background-color: ${color}'>` + innerHTML.substring(index, index + text.length) + '</mark>' + innerHTML.substring(index + text.length);
+        innerHTML = innerHTML.substring(0, index) + `<mark style='background-color: ${color}'>` + innerHTML.substring(index, index + text.length) + '</mark>' + innerHTML.substring(index + text.length);
         wikiText.innerHTML = innerHTML;
     }
 }
 
-// Highlight the entire (content) text of a Wikipedia page. Why? Testing
-let wikiContent = document.getElementById('mw-content-text');
-wikiContent.style.backgroundColor = '#CDE8FF';
-
 renderGraphOverlay();
-
-// Edge case: note how it didn't highlight the links
-const persistent = ['ranked #1 in Undergraduate Teaching by U.S. News & World Report for over a decade', 'Founded in 1866', 
-                    'Admissions is highly selective', 'Carleton is one of the highest sources of undergraduate students pursuing doctorates'];
-var arrayLength = persistent.length;
-for (var i = 0; i < arrayLength; i++) {
-    highlightPersistentContent(persistent[i], '#99FF84');
-}

--- a/WikiExtension/src/content.js
+++ b/WikiExtension/src/content.js
@@ -1,5 +1,5 @@
 /* Creates the div for the graph overlay. TODO: create the graph and render it here */
-function renderGraphOverlay() {
+let renderGraphOverlay = () => {
     let graphContainer = document.createElement('div');
     graphContainer.style.cssText = 'width:40%;height:180px;background-color:#E3C2FF;';
 
@@ -17,7 +17,7 @@ let wikiText = document.getElementById('mw-content-text');
 let innerHTML = wikiText.innerHTML;
 
 /* Highlights the words that are given */
-function highlightPersistentContent(text, color) {
+let highlightPersistentContent = (text, color) => {
     let index = innerHTML.indexOf(text);
     if (index >= 0) { 
         innerHTML = innerHTML.substring(0, index) + `<mark style='background-color: ${color}'>` + innerHTML.substring(index, index + text.length) + '</mark>' + innerHTML.substring(index + text.length);


### PR DESCRIPTION
Add function to highlight wikipedia text and another one to render a div after wikipedia header for the graph. 
Add instructions on how to use the highlighting function. 

<img width="1371" alt="Captura de Tela 2022-10-18 às 1 22 53 PM" src="https://user-images.githubusercontent.com/36846401/196529083-0db60e68-4f71-42c1-9807-54e585bbea2c.png">
