### PR TITLE
Add requirement in package.json to check if we are using the right node version

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,9 @@
     "": {
       "dependencies": {
         "node-fetch": "^3.2.10"
+      },
+      "engines": {
+        "node": ">=16.18.0 <17.0.0"
       }
     },
     "node_modules/data-uri-to-buffer": {

--- a/package.json
+++ b/package.json
@@ -2,5 +2,8 @@
   "type": "module",
   "dependencies": {
     "node-fetch": "^3.2.10"
+  },
+  "engines": {
+    "node": ">=16.18.0 <17.0.0"
   }
 }


### PR DESCRIPTION
- Add a requirement to require node version `16.18.x` or the latest lts version.

When running `npm install`, if you have the wrong version of node, it will show something like
```
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: undefined
npm ERR! notsup Not compatible with your version of node/npm: undefined
npm ERR! notsup Required: {"node":">=16.18.0 <17.0.0"}
npm ERR! notsup Actual:   {"npm":"7.13.0","node":"v10.23.0"}
```

If the node version is correct, it will show something like
```
up to date, audited 7 packages in 457ms

3 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```

Had to do this because fetch, for example, needs a more recent version of node.

In that case, install a newer version of node or use Node Version Manager (nvm) to switch between versions. (I am currently using nvm).
Link to install: https://medium.com/devops-techable/how-to-install-nvm-node-version-manager-on-macos-with-homebrew-1bc10626181