### PR TITLE
Add revision count endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ const pastaRevisionResponse = await getPageRevisionCount(
 console.log(pastaRevisionResponse);
 /*
     Returns:
-    {
-        'Sat Jan 15 2022 00:00:00 GMT-0600 (Central Standard Time)': 1,
-        'Sat Jan 08 2022 00:00:00 GMT-0600 (Central Standard Time)': 1
-    }
+    [
+        [ 'Sat Jan 15 2022 00:00:00 GMT-0600 (Central Standard Time)', 1 ],
+        [ 'Sat Jan 08 2022 00:00:00 GMT-0600 (Central Standard Time)', 1 ]
+    ]
 */
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Use enums.js as inputs for some of the parameters if needed.
 
 ```javascript
 import { WIKI_CREATION_DATE, AggregateType } from "./enums.js";
-import getPageViews from "./timeseriesService.js";
+import { getPageViews } from "./timeseriesService.js";
 
 // Get page views for the Pasta article since its creation until the beginning of 2022 by day
 const pastaResponse = await getPageViews("Pasta", WIKI_CREATION_DATE, new Date("2022-01-01"), AggregateType.DAILY);
@@ -45,6 +45,29 @@ const pastaResponse = await getPageViews("Pasta", WIKI_CREATION_DATE, new Date("
         ...
     ]
  */
+```
+
+### How to get revision count
+
+```javascript
+import { AggregateType } from "./enums.js";
+import { getPageRevisionCount } from "./timeseriesService.js";
+
+// Get monthly revision count for the Pasta article from Jan 2022
+const pastaRevisionResponse = await getPageRevisionCount(
+    "Pasta",
+    new Date("2022-01-01"),
+    new Date("2022-01-31"),
+    AggregateType.DAILY
+);
+console.log(pastaRevisionResponse);
+/*
+    Returns:
+    {
+        'Sat Jan 15 2022 00:00:00 GMT-0600 (Central Standard Time)': 1,
+        'Sat Jan 08 2022 00:00:00 GMT-0600 (Central Standard Time)': 1
+    }
+*/
 ```
 
 ## [Website](https://sukritsangvong.github.io/wp-browser-extension/)

--- a/WikiExtension/src/timeSeriesService.js
+++ b/WikiExtension/src/timeSeriesService.js
@@ -1,4 +1,5 @@
 import fetch from "node-fetch";
+import { AggregateType } from "./enums.js";
 
 const formatDateToYYYMMDD = (date) =>
     `${date.getFullYear()}${("0" + (date.getMonth() + 1)).slice(-2)}${("0" + date.getDate()).slice(-2)}`;
@@ -11,10 +12,10 @@ const formatYYYYMMDDToDate = (yyyymmdd) =>
  * if the startDate comes before the article was created.
  *
  * @param {string} title of a wikipedia article
- * @param {Date} startTimestamp in a format of YYYYMMDD
- * @param {Date} endDate in a format of YYYYMMDD
+ * @param {Date} startDate
+ * @param {Date} endDate
  * @param {string} aggregateType of either monthly or daily
- * @return {map} of an item of list with properties project, article, granularity(aggregationType), timestamp, access, agent, views
+ * @return {map} of an item of list with properties project, article, granularity(aggregateType), timestamp, access, agent, views
  */
 const fetchPageViews = async (title, startDate, endDate, aggregateType) => {
     const formattedStartDate = formatDateToYYYMMDD(startDate);
@@ -26,6 +27,52 @@ const fetchPageViews = async (title, startDate, endDate, aggregateType) => {
 };
 
 /**
+ * Get all the revision objects on a given wikipedia title.
+ *
+ * The api only give us at most 20 reivision objects per request. However, it does give us a query to
+ * use if there are any older revisions. If older versions of revision existm, we will get
+ * {
+ *  revisions: [...],
+ *  ...
+ *  older: 'https://en.wikipedia.org/w/rest.php/v1/page/Jupiter/history?older_than=1103899458',
+ *  ...
+ * }
+ *
+ * Thus, we keep calling the endpoint with the given querys if the older property exists in the
+ * previous request.
+ *
+ * @param {string} title of a wikipedia article
+ * @param {Date} startDate
+ * @param {Date} endDate
+ * @returns An array containing all revision objects
+ */
+const fetchPageRevisions = async (title, startDate, endDate) => {
+    const response = await fetch(`https://en.wikipedia.org/w/rest.php/v1/page/${title}/history`);
+    let curJsonResponse = await response.json();
+
+    let revisions = curJsonResponse.revisions;
+
+    while (curJsonResponse.hasOwnProperty("older")) {
+        const localResponse = await fetch(curJsonResponse.older);
+        curJsonResponse = await localResponse.json();
+
+        const localRevisions = curJsonResponse.revisions;
+
+        // Stop making requests when requesting passes startDate
+        const localLatestTimestamp = new Date(localRevisions[0].timestamp);
+        if (localLatestTimestamp < startDate) break;
+
+        revisions.push(...localRevisions);
+    }
+
+    // Filters revisions that are in between the given timerange.
+    return revisions.filter((revisionObject) => {
+        const currentTimestamp = new Date(revisionObject.timestamp);
+        return startDate <= currentTimestamp && currentTimestamp <= endDate;
+    });
+};
+
+/**
  * TODO: Subject to change based on what the graph needs
  * @return formated fetchedPageViews as a list of lists that only contain date object and count
  */
@@ -33,6 +80,30 @@ const formatPageViews = (fetchedPageViews) => {
     return Array.from(fetchedPageViews.items).map((pageViewObject) => {
         return [formatYYYYMMDDToDate(pageViewObject.timestamp), pageViewObject.views];
     });
+};
+
+/**
+ * TODO: Subject to change based on what the graph needs
+ * @param {AggregateType} aggregateType
+ * @return formated fetchedRevisions as a list of lists that only contain date object and count
+ */
+const formatPageRevisions = (fetchedRevisions, aggregateType) => {
+    return fetchedRevisions
+        .map((revisionObject) => {
+            const date = new Date(revisionObject.timestamp);
+            date.setHours(0, 0, 0, 0); // have date only contain year, month, and day (not time)
+
+            // Reduce dates to 1 to aggregate monthly instead of daily
+            if (aggregateType == AggregateType.MONTHLY) {
+                date.setDate(1);
+            }
+
+            return date;
+        })
+        .reduce((accumulator, timestamp) => {
+            accumulator[timestamp] = (accumulator[timestamp] ?? 0) + 1;
+            return accumulator;
+        }, {});
 };
 
 /**
@@ -53,8 +124,22 @@ const getPageViews = async (title, startDate, endDate, aggregateType) => {
         console.error(
             `Error fetching page views on inputs title:${title} startDate:${startDate} endDate:${endDate} aggregateType:${aggregateType}\nError: ${err.message}`
         );
-        return null;
+        return err;
     }
 };
 
-export default getPageViews;
+const getPageRevisionCount = async (title, startDate, endDate, aggregateType) => {
+    try {
+        let result = await fetchPageRevisions(title, startDate, endDate);
+        let formattedResult = formatPageRevisions(result, aggregateType);
+        return formattedResult;
+    } catch (err) {
+        console.error(
+            `Error fetching revision count on inputs title:${title} startDate:${startDate} endDate:${endDate} aggregateType:${aggregateType}\nError: ${err.message}`
+        );
+
+        return err;
+    }
+};
+
+export { getPageViews, getPageRevisionCount };

--- a/WikiExtension/src/timeSeriesService.js
+++ b/WikiExtension/src/timeSeriesService.js
@@ -15,7 +15,7 @@ const formatYYYYMMDDToDate = (yyyymmdd) =>
  * @param {Date} startDate
  * @param {Date} endDate
  * @param {string} aggregateType of either monthly or daily
- * @return {map} of an item of list with properties project, article, granularity(aggregateType), timestamp, access, agent, views
+ * @return {map} of an item of an array with properties project, article, granularity(aggregateType), timestamp, access, agent, views
  */
 const fetchPageViews = async (title, startDate, endDate, aggregateType) => {
     const formattedStartDate = formatDateToYYYMMDD(startDate);
@@ -29,8 +29,8 @@ const fetchPageViews = async (title, startDate, endDate, aggregateType) => {
 /**
  * Get all the revision objects on a given wikipedia title.
  *
- * The api only give us at most 20 reivision objects per request. However, it does give us a query to
- * use if there are any older revisions. If older versions of revision existm, we will get
+ * The api only gives us at most 20 reivision objects per request. However, it does give us a query to
+ * use if there are any older revisions. If older versions of revision exists, we will get
  * {
  *  revisions: [...],
  *  ...
@@ -38,7 +38,7 @@ const fetchPageViews = async (title, startDate, endDate, aggregateType) => {
  *  ...
  * }
  *
- * Thus, we keep calling the endpoint with the given querys if the older property exists in the
+ * Thus, we keep calling the endpoint with the given query if the older property exists in the
  * previous request.
  *
  * @param {string} title of a wikipedia article
@@ -65,7 +65,7 @@ const fetchPageRevisions = async (title, startDate, endDate) => {
         revisions.push(...localRevisions);
     }
 
-    // Filters revisions that are in between the given timerange.
+    // Filters revisions that are in between the given timerange
     return revisions.filter((revisionObject) => {
         const currentTimestamp = new Date(revisionObject.timestamp);
         return startDate <= currentTimestamp && currentTimestamp <= endDate;
@@ -74,7 +74,7 @@ const fetchPageRevisions = async (title, startDate, endDate) => {
 
 /**
  * TODO: Subject to change based on what the graph needs
- * @return formated fetchedPageViews as a list of lists that only contain date object and count
+ * @return formated fetchedPageViews as an array of arrays that only contain date object and count
  */
 const formatPageViews = (fetchedPageViews) => {
     return Array.from(fetchedPageViews.items).map((pageViewObject) => {
@@ -85,15 +85,15 @@ const formatPageViews = (fetchedPageViews) => {
 /**
  * TODO: Subject to change based on what the graph needs
  * @param {AggregateType} aggregateType
- * @return formated fetchedRevisions as a list of lists that only contain date object and count
+ * @return formated fetchedRevisions as an array of arrays that only contain date object and count
  */
 const formatPageRevisions = (fetchedRevisions, aggregateType) => {
     const pageRevisionCountMap = fetchedRevisions
         .map((revisionObject) => {
             const date = new Date(revisionObject.timestamp);
-            date.setHours(0, 0, 0, 0); // have date only contain year, month, and day (not time)
+            date.setHours(0, 0, 0, 0); // have date only contains year, month, and day (not time)
 
-            // Reduce dates to 1 to aggregate monthly instead of daily
+            // Set date to 1 to aggregate monthly instead of daily
             if (aggregateType == AggregateType.MONTHLY) {
                 date.setDate(1);
             }
@@ -105,7 +105,7 @@ const formatPageRevisions = (fetchedRevisions, aggregateType) => {
             return accumulator;
         }, {});
 
-    // Formats into list of lists
+    // Formats into an array of arrays
     return Object.keys(pageRevisionCountMap).map((key) => [key, pageRevisionCountMap[key]]);
 };
 
@@ -116,7 +116,7 @@ const formatPageRevisions = (fetchedRevisions, aggregateType) => {
  * @param {Date} startDate
  * @param {Date} endDate
  * @param {AggregateType} aggregateType an enum that represents string "monthly" or "daily"
- * @returns aggregated list of data of views per day or per month
+ * @returns aggregated array of data of views per day or per month
  */
 const getPageViews = async (title, startDate, endDate, aggregateType) => {
     try {
@@ -131,6 +131,15 @@ const getPageViews = async (title, startDate, endDate, aggregateType) => {
     }
 };
 
+/**
+ * Get revision counts on a given article within a given time range.
+ *
+ * @param {string} title of a wikipedia article
+ * @param {Date} startDate
+ * @param {Date} endDate
+ * @param {AggregateType} aggregateType an enum that represents string "monthly" or "daily"
+ * @returns aggregated array of data of revision counts per day or per month
+ */
 const getPageRevisionCount = async (title, startDate, endDate, aggregateType) => {
     try {
         let result = await fetchPageRevisions(title, startDate, endDate);

--- a/WikiExtension/src/timeSeriesService.js
+++ b/WikiExtension/src/timeSeriesService.js
@@ -88,7 +88,7 @@ const formatPageViews = (fetchedPageViews) => {
  * @return formated fetchedRevisions as a list of lists that only contain date object and count
  */
 const formatPageRevisions = (fetchedRevisions, aggregateType) => {
-    return fetchedRevisions
+    const pageRevisionCountMap = fetchedRevisions
         .map((revisionObject) => {
             const date = new Date(revisionObject.timestamp);
             date.setHours(0, 0, 0, 0); // have date only contain year, month, and day (not time)
@@ -104,6 +104,9 @@ const formatPageRevisions = (fetchedRevisions, aggregateType) => {
             accumulator[timestamp] = (accumulator[timestamp] ?? 0) + 1;
             return accumulator;
         }, {});
+
+    // Formats into list of lists
+    return Object.keys(pageRevisionCountMap).map((key) => [key, pageRevisionCountMap[key]]);
 };
 
 /**


### PR DESCRIPTION
- Add an endpoint to get revision count given a Wikipedia page title

Can see how to use it in README.md.
https://github.com/sukritsangvong/wp-browser-extension/tree/sangvongp/revision-count-endpoint#how-to-get-revision-count

Update:
Note that if we are getting all the revisions of a page, it may take almost a minute to fetch all the history. It can only get 20 histories per request, so we have to request `totalNumRevisions`/20 times to get everything.