### PR TITLE
Add endpoints to format page view count and page revision edits 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,18 +35,15 @@ for (var i = 0; i < arrayLength; i++) {
 Use enums.js as inputs for some of the parameters if needed.
 
 ```javascript
-import { WIKI_CREATION_DATE, AggregateType } from "./enums.js";
-import { getPageViews } from "./timeseriesService.js";
+import { getPageViewTimeseries } from "./timeseriesService.js";
 
-// Get page views for the Pasta article since its creation until the beginning of 2022 by day
-const pastaResponse = await getPageViews("Pasta", WIKI_CREATION_DATE, new Date("2022-01-01"), AggregateType.DAILY);
+// Get page views for the Pasta article
+const pastaResponse = await getPageViewTimeseries("Pasta", new Date("2015-07-01"), new Date("2022-01-01"));
 /*
     Returns:
     {
-        {"7/1/2015" => 2406},
-        {"7/2/2015" => 2076},
-        {"7/3/2015" => 1890},
-        ...
+        x: ["7/1/2015", "7/2/2015", ...]
+        y: [2406, 2076, ...]
     }
  */
 ```
@@ -54,22 +51,19 @@ const pastaResponse = await getPageViews("Pasta", WIKI_CREATION_DATE, new Date("
 ### How to get revision count
 
 ```javascript
-import { AggregateType } from "./enums.js";
-import { getPageRevisionCount } from "./timeseriesService.js";
+import { getPageRevisionCountTimeseries } from "./timeseriesService.js";
 
-// Get monthly revision count for the Pasta article from Jan 2022
-const pastaRevisionResponse = await getPageRevisionCount(
+// Get revision count for the Pasta article from Jan 2022
+const pastaRevisionResponse = await getPageRevisionCountTimeseries(
     "Pasta",
     new Date("2022-01-01"),
-    new Date("2022-01-31"),
-    AggregateType.DAILY
+    new Date("2022-01-31")
 );
-console.log(pastaRevisionResponse);
 /*
     Returns:
     {
-        {"1/15/2022" => 1},
-        {"1/8/2022" => 1}
+        x: ["1/1/2022", ..., "1/8/2022", ...]
+        y: [0, 0, ..., 1, ...]
     }
 */
 ```

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 ### Set Up
 
 1. Make sure node 16.18.0 is installed - you can do this using nvm (node version manger)
-2. ```cd wikichange```
-3. ```npm install```
-4. ```npm run start``` (dev build) or ```npm run build``` (production build) 
+2. `cd wikichange`
+3. `npm install`
+4. `npm run start` (dev build) or `npm run build` (production build)
 5. Visit [chrome://extensions/](chrome://extensions/) and toggle developper mode ON
 6. For dev build click on `Load unpacked` and select the wikichange/dist folder
 
@@ -42,14 +42,12 @@ import { getPageViews } from "./timeseriesService.js";
 const pastaResponse = await getPageViews("Pasta", WIKI_CREATION_DATE, new Date("2022-01-01"), AggregateType.DAILY);
 /*
     Returns:
-    [
-        [ 2015-07-01T05:00:00.000Z, 2406 ],
-        [ 2015-07-02T05:00:00.000Z, 2076 ],
-        [ 2015-07-03T05:00:00.000Z, 1890 ],
-        [ 2015-07-04T05:00:00.000Z, 1770 ],
-        [ 2015-07-05T05:00:00.000Z, 1941 ],
+    {
+        {"7/1/2015" => 2406},
+        {"7/2/2015" => 2076},
+        {"7/3/2015" => 1890},
         ...
-    ]
+    }
  */
 ```
 
@@ -69,10 +67,10 @@ const pastaRevisionResponse = await getPageRevisionCount(
 console.log(pastaRevisionResponse);
 /*
     Returns:
-    [
-        [ 'Sat Jan 15 2022 00:00:00 GMT-0600 (Central Standard Time)', 1 ],
-        [ 'Sat Jan 08 2022 00:00:00 GMT-0600 (Central Standard Time)', 1 ]
-    ]
+    {
+        {"1/15/2022" => 1},
+        {"1/8/2022" => 1}
+    }
 */
 ```
 

--- a/wikichange/src/content/content.js
+++ b/wikichange/src/content/content.js
@@ -1,78 +1,97 @@
-import { WIKI_CREATION_DATE, AggregateType } from "./enums.js";
-import { getPageViews, getPageCreationDate } from "./timeSeriesService.js";
+import { getPageCreationDate } from "./timeSeriesService.js";
+import injectGraphToPage from "./graph.js";
 
 const insertAfter = (newNode, existingNode) => {
     existingNode.parentNode.insertBefore(newNode, existingNode.nextSibling);
-}
-
-/* Creates the div for the graph overlay. TODO: create the graph and render it here */
-const renderGraphOverlay = () => {
-    let floatContainer = document.createElement('div');
-    floatContainer.style.cssText = 'display: flex;';
-    floatContainer.setAttribute('id', 'floatContainer');
-
-    let graphContainer = document.createElement('div');
-    graphContainer.setAttribute('id', 'graphOverlay');
-
-    let canvas = document.createElement('canvas');
-    canvas.style.maxHeight = '200px';
-    canvas.id = 'viewsEditsChart';
-    graphContainer.style.cssText = 'width:75%;height:20%;';
-    graphContainer.appendChild(canvas);
-
-    floatContainer.appendChild(graphContainer);
-
-    let p = document.createElement('p');
-    graphContainer.appendChild(p);
-
-    let siteSub = document.getElementById('siteSub');
-    insertAfter(floatContainer, siteSub);
-}
-
-/* Add simple slider to graph. Equivalency between dates and integers: 0: today, 100: creation date */
-const renderSlider = (creationDate) => {
-    let now = new Date();
-    let totalDaysDiff =  (now.getTime() - creationDate.getTime())/(1000 * 3600 * 24);
-    let viewsEditsChart = document.getElementById('viewsEditsChart');
-    let sliderDiv = document.createElement('div');
-    sliderDiv.innerHTML = `<div style="direction: rtl">${now.toISOString().slice(0, 10)}  <input type="range" id="graphSlider" value="100" min="0" max="100" style="width:60%;">  ${creationDate.toISOString().slice(0, 10)}</div>
-                            <br/><input type="date" value="${creationDate.toISOString().slice(0, 10)}" id="dateOutput" name="dateOutput" style="text-align: center;"> <button onclick="alert('WIP')">Highlight</button><br>`;
-    sliderDiv.style.cssText = 'text-align:center;';
-    insertAfter(sliderDiv, viewsEditsChart);
-
-    let slider = document.getElementById('graphSlider');
-    slider.addEventListener('change', function (ev) {
-        let numDays = parseInt(totalDaysDiff*this.value/100);
-        let date = new Date();
-        date.setDate(now.getDate() - numDays);
-        document.getElementById('dateOutput').value = date.toISOString().slice(0, 10);
-    });
-}
+};
 
 /* Get the title of a Wikipedia page by inspecting the html */
 const title = (() => {
-    let titleSpan = document.getElementsByClassName('mw-page-title-main');
+    let titleSpan = document.getElementsByClassName("mw-page-title-main");
     let title = titleSpan[0].innerHTML;
     return title;
 })();
 
+/* Creates the div for the graph overlay. TODO: create the graph and render it here */
+const renderGraphOverlay = async () => {
+    let floatContainer = document.createElement("div");
+    floatContainer.style.cssText = "display: flex;";
+    floatContainer.setAttribute("id", "floatContainer");
+
+    let graphContainer = document.createElement("div");
+    graphContainer.setAttribute("id", "graphOverlay");
+
+    let canvas = document.createElement("canvas");
+    canvas.style.maxHeight = "200px";
+    canvas.id = "viewsEditsChart";
+    graphContainer.style.cssText = "width:75%;height:20%;";
+    graphContainer.appendChild(canvas);
+
+    floatContainer.appendChild(graphContainer);
+
+    let p = document.createElement("p");
+    graphContainer.appendChild(p);
+
+    let siteSub = document.getElementById("siteSub");
+    insertAfter(floatContainer, siteSub);
+    const creationDate = await getPageCreationDate();
+    injectGraphToPage(title, creationDate, new Date(Date.now()));
+};
+
+/* Add simple slider to graph. Equivalency between dates and integers: 0: today, 100: creation date */
+const renderSlider = (creationDate) => {
+    let now = new Date();
+    let totalDaysDiff = (now.getTime() - creationDate.getTime()) / (1000 * 3600 * 24);
+    let viewsEditsChart = document.getElementById("viewsEditsChart");
+    let sliderDiv = document.createElement("div");
+    sliderDiv.innerHTML = `<div style="direction: rtl">${now
+        .toISOString()
+        .slice(
+            0,
+            10
+        )}  <input type="range" id="graphSlider" value="100" min="0" max="100" style="width:60%;">  ${creationDate
+        .toISOString()
+        .slice(0, 10)}</div>
+                            <br/><input type="date" value="${creationDate
+                                .toISOString()
+                                .slice(
+                                    0,
+                                    10
+                                )}" id="dateOutput" name="dateOutput" style="text-align: center;"> <button onclick="alert('WIP')">Highlight</button><br>`;
+    sliderDiv.style.cssText = "text-align:center;";
+    insertAfter(sliderDiv, viewsEditsChart);
+
+    let slider = document.getElementById("graphSlider");
+    slider.addEventListener("change", function (ev) {
+        let numDays = parseInt((totalDaysDiff * this.value) / 100);
+        let date = new Date();
+        date.setDate(now.getDate() - numDays);
+        document.getElementById("dateOutput").value = date.toISOString().slice(0, 10);
+    });
+};
+
 renderGraphOverlay();
-getPageCreationDate(title).then(function(date) {
+getPageCreationDate(title).then(function (date) {
     renderSlider(date);
 });
 
-// Get wikipedia text, global as we shouldn't get it every time we highlight a word 
-let wikiText = document.getElementById('mw-content-text');
+// Get wikipedia text, global as we shouldn't get it every time we highlight a word
+let wikiText = document.getElementById("mw-content-text");
 let innerHTML = wikiText.innerHTML;
 
 /* Highlights the words that are given */
 const highlightPersistentContent = (text, color) => {
     let index = innerHTML.indexOf(text);
-    if (index >= 0) { 
-        innerHTML = innerHTML.substring(0, index) + `<mark style='background-color: ${color}'>` + innerHTML.substring(index, index + text.length) + '</mark>' + innerHTML.substring(index + text.length);
+    if (index >= 0) {
+        innerHTML =
+            innerHTML.substring(0, index) +
+            `<mark style='background-color: ${color}'>` +
+            innerHTML.substring(index, index + text.length) +
+            "</mark>" +
+            innerHTML.substring(index + text.length);
         wikiText.innerHTML = innerHTML;
     }
-}
+};
 
 /* The page id can be found as the last part of the link to
  * the wikidata item on the left side of wikipedia pages.
@@ -81,31 +100,34 @@ const highlightPersistentContent = (text, color) => {
 (() => {
     let wiki_data_url;
     try {
-        wiki_data_url = document.getElementById('t-wikibase').getElementsByTagName('a')[0].href;
+        wiki_data_url = document.getElementById("t-wikibase").getElementsByTagName("a")[0].href;
     } catch {
         throw new Error("'Can't find page id!");
     }
-    const wiki_page_id = wiki_data_url.split('/').slice(-1)[0];
+    const wiki_page_id = wiki_data_url.split("/").slice(-1)[0];
     console.info({
-        'wiki_data_url': wiki_data_url,
-        'wiki_page_id': wiki_page_id
+        wiki_data_url: wiki_data_url,
+        wiki_page_id: wiki_page_id,
     });
-    return(wiki_page_id);
+    return wiki_page_id;
 })();
 
 const renderDeleteAlert = (count) => {
-    let deleteContainer = document.createElement('div');
-    deleteContainer.innerHTML = `<div class="card" style="max-width: 18rem;border-style: solid;padding: 0.5rem;float: left;">
+    let deleteContainer = document.createElement("div");
+    deleteContainer.innerHTML =
+        `<div class="card" style="max-width: 18rem;border-style: solid;padding: 0.5rem;float: left;">
                                     <div class="card-body">
                                     <h5 class="card-title">Deletions</h5>
-                                    <p class="card-text">This article had ` + count + ` bytes of deleted content not shown in this overlay</p>
+                                    <p class="card-text">This article had ` +
+        count +
+        ` bytes of deleted content not shown in this overlay</p>
                                     </div>
                                 </div>`;
-    deleteContainer.setAttribute('id', 'deleteAlert');
-    deleteContainer.style.cssText = 'padding:2.5%;';
+    deleteContainer.setAttribute("id", "deleteAlert");
+    deleteContainer.style.cssText = "padding:2.5%;";
 
-    let floatContainer = document.getElementById('floatContainer');
+    let floatContainer = document.getElementById("floatContainer");
     floatContainer.append(deleteContainer);
-}
+};
 
 renderDeleteAlert(100);

--- a/wikichange/src/content/content.js
+++ b/wikichange/src/content/content.js
@@ -38,13 +38,6 @@ const renderGraphOverlay = async () => {
     injectGraphToPage(title, creationDate, new Date(Date.now()));
 };
 
-/* Get the title of a Wikipedia page by inspecting the html */
-const title = (() => {
-    let titleSpan = document.getElementsByClassName("mw-page-title-main");
-    let title = titleSpan[0].innerHTML;
-    return title;
-})();
-
 /* Add simple slider to graph. Equivalency between dates and integers: 0: today, 100: creation date */
 const renderSlider = (creationDate) => {
     let now = new Date();

--- a/wikichange/src/content/content.js
+++ b/wikichange/src/content/content.js
@@ -40,7 +40,7 @@ const renderGraphOverlay = async () => {
 
 /* Get the title of a Wikipedia page by inspecting the html */
 const title = (() => {
-    let titleSpan = document.getElementsByClassName('mw-page-title-main');
+    let titleSpan = document.getElementsByClassName("mw-page-title-main");
     let title = titleSpan[0].innerHTML;
     return title;
 })();
@@ -48,45 +48,47 @@ const title = (() => {
 /* Add simple slider to graph. Equivalency between dates and integers: 0: today, 100: creation date */
 const renderSlider = (creationDate) => {
     let now = new Date();
-    let totalDaysDiff =  (now.getTime() - creationDate.getTime())/(1000 * 3600 * 24);
-    let viewsEditsChart = document.getElementById('viewsEditsChart');
-    let sliderDiv = document.createElement('div');
+    let totalDaysDiff = (now.getTime() - creationDate.getTime()) / (1000 * 3600 * 24);
+    let viewsEditsChart = document.getElementById("viewsEditsChart");
+    let sliderDiv = document.createElement("div");
     let initialDate = new Date();
-    initialDate.setDate(now.getDate() - (totalDaysDiff*0.5));
+    initialDate.setDate(now.getDate() - totalDaysDiff * 0.5);
     // let closestRevision = fetchRevisionFromDate(title, initialDate)
 
     sliderDiv.innerHTML = `<div style="direction: rtl">${now.toISOString().slice(0, 10)}  
                                 <input type="range" id="graphSlider" value="50" min="0" max="100" style="width:60%;">  
                                 ${creationDate.toISOString().slice(0, 10)}
                             </div>
-                            <br/><input type="date" value="${initialDate.toISOString().slice(0, 10)}" id="dateOutput" name="dateOutput" style="text-align: center;"> 
+                            <br/><input type="date" value="${initialDate
+                                .toISOString()
+                                .slice(0, 10)}" id="dateOutput" name="dateOutput" style="text-align: center;"> 
                                 <button id = "highlightButton">Highlight</button><p id="revisionDate">Showing highlight for closest revision (<b>date: <span id="closesRev"></span></b>)</p>`;
-    sliderDiv.style.cssText = 'text-align:center;';
+    sliderDiv.style.cssText = "text-align:center;";
     insertAfter(sliderDiv, viewsEditsChart);
 
-    let slider = document.getElementById('graphSlider');
-    let dateInput = document.getElementById('dateOutput');
-    let button = document.getElementById('highlightButton');
+    let slider = document.getElementById("graphSlider");
+    let dateInput = document.getElementById("dateOutput");
+    let button = document.getElementById("highlightButton");
 
-    slider.addEventListener('change', function (ev) {
-        let numDays = parseInt(totalDaysDiff*this.value/100);
+    slider.addEventListener("change", function (ev) {
+        let numDays = parseInt((totalDaysDiff * this.value) / 100);
         let date = new Date();
         date.setDate(now.getDate() - numDays);
         dateInput.value = date.toISOString().slice(0, 10);
     });
 
-    dateInput.addEventListener('change', function (ev) {
-        let daysDiff = (new Date(this.value).getTime() - creationDate.getTime())/(1000 * 3600 * 24);
-        let sliderVal = 100 - (daysDiff/totalDaysDiff)*100;
+    dateInput.addEventListener("change", function (ev) {
+        let daysDiff = (new Date(this.value).getTime() - creationDate.getTime()) / (1000 * 3600 * 24);
+        let sliderVal = 100 - (daysDiff / totalDaysDiff) * 100;
         slider.value = sliderVal;
     });
 
-    button.addEventListener('click', function(ev) {
-        let spanClosestRev = document.getElementById('closesRev');
+    button.addEventListener("click", function (ev) {
+        let spanClosestRev = document.getElementById("closesRev");
         // call fetchRevisionFromDate(title, dateInput.value)
         spanClosestRev.innerHTML = dateInput.value;
     });
-}
+};
 
 renderGraphOverlay();
 getPageCreationDate(title).then(function (date) {

--- a/wikichange/src/content/graph.js
+++ b/wikichange/src/content/graph.js
@@ -32,12 +32,14 @@ const injectGraphToPage = async (title, startDate, endDate) => {
                 data: pageViews["y"],
                 borderColor: CHART_COLORS.red,
                 yAxisID: "y",
+                borderWidth: 2,
             },
             {
                 label: "Edits",
                 data: revisions["y"],
                 borderColor: CHART_COLORS.blue,
                 yAxisID: "y1",
+                borderWidth: 2,
             },
         ],
     };
@@ -68,6 +70,11 @@ const injectGraphToPage = async (title, startDate, endDate) => {
                     grid: {
                         drawOnChartArea: false, // only want the grid lines for one axis to show up
                     },
+                },
+            },
+            elements: {
+                point: {
+                    radius: 0,
                 },
             },
         },

--- a/wikichange/src/content/graph.js
+++ b/wikichange/src/content/graph.js
@@ -1,74 +1,79 @@
-import Chart from 'chart.js/auto';
+import Chart from "chart.js/auto";
+import { getPageViewTimeseries, getPageRevisionCountTimeseries } from "./timeSeriesService.js";
 
 const CHART_COLORS = {
-    red: 'rgb(255, 99, 132)',
-    orange: 'rgb(255, 159, 64)',
-    yellow: 'rgb(255, 205, 86)',
-    green: 'rgb(75, 192, 192)',
-    blue: 'rgb(54, 162, 235)',
-    purple: 'rgb(153, 102, 255)',
-    grey: 'rgb(201, 203, 207)'
+    red: "rgb(255, 99, 132)",
+    orange: "rgb(255, 159, 64)",
+    yellow: "rgb(255, 205, 86)",
+    green: "rgb(75, 192, 192)",
+    blue: "rgb(54, 162, 235)",
+    purple: "rgb(153, 102, 255)",
+    grey: "rgb(201, 203, 207)",
 };
 
-const labels = [
-    'January',
-    'February',
-    'March',
-    'April',
-    'May',
-    'June',
-];
+/**
+ * Injects a graph of a given article's page views and edits data.
+ *
+ * @param {string} title of the article
+ * @param {Date} startDate
+ * @param {Date} endDate
+ */
+const injectGraphToPage = async (title, startDate, endDate) => {
+    const pageViews = await getPageViewTimeseries(title, startDate, endDate);
+    const revisions = await getPageRevisionCountTimeseries(title, startDate, endDate);
 
-const data = {
-    labels: labels,
-    datasets: [
-        {
-            label: 'Dataset 1',
-            data: [0, 10, 5, 2, 20, 30, 45],
-            borderColor: CHART_COLORS.red,
-            yAxisID: 'y',
-        },
-        {
-            label: 'Dataset 2',
-            data: [10, 1, 34, 24, 17, 55, 45],
-            borderColor: CHART_COLORS.blue,
-            yAxisID: 'y1',
-        }
-    ]
-};
+    const xLabels = pageViews["x"];
 
-const config = {
-    type: 'line',
-    data: data,
-    options: {
-        scales: {
-            y: {
-                type: 'linear',
-                display: true,
-                position: 'left',
-                title: {
-                    display: true,
-                    text: 'Views'
-                }
+    const data = {
+        labels: xLabels,
+        datasets: [
+            {
+                label: "Views",
+                data: pageViews["y"],
+                borderColor: CHART_COLORS.red,
+                yAxisID: "y",
             },
-            y1: {
-                type: 'linear',
-                display: true,
-                position: 'right',
-                title: {
+            {
+                label: "Edits",
+                data: revisions["y"],
+                borderColor: CHART_COLORS.blue,
+                yAxisID: "y1",
+            },
+        ],
+    };
+
+    const config = {
+        type: "line",
+        data: data,
+        options: {
+            scales: {
+                y: {
+                    type: "linear",
                     display: true,
-                    text: 'Edits',
+                    position: "left",
+                    title: {
+                        display: true,
+                        text: "Views",
+                    },
                 },
-                // grid line settings
-                grid: {
-                    drawOnChartArea: false, // only want the grid lines for one axis to show up
+                y1: {
+                    type: "linear",
+                    display: true,
+                    position: "right",
+                    title: {
+                        display: true,
+                        text: "Edits",
+                    },
+                    // grid line settings
+                    grid: {
+                        drawOnChartArea: false, // only want the grid lines for one axis to show up
+                    },
                 },
-            }
-        }
-    }
+            },
+        },
+    };
+
+    new Chart(document.getElementById("viewsEditsChart"), config);
 };
 
-const myChart = new Chart(
-    document.getElementById('viewsEditsChart'),
-    config
-);
+export default injectGraphToPage;

--- a/wikichange/src/content/timeSeriesService.js
+++ b/wikichange/src/content/timeSeriesService.js
@@ -7,7 +7,8 @@ const formatYYYYMMDDToDate = (yyyymmdd) =>
     new Date(yyyymmdd.substring(0, 4), yyyymmdd.substring(4, 6) - 1, yyyymmdd.substring(6, 8));
 
 // Gets number of days from date1 to date2 (inclusive)
-const getDiffDaysBetweenTwoDates = (date1, date2) => (date2.getTime() - date1.getTime()) / (1000 * 3600 * 24) + 1;
+const getDiffDaysBetweenTwoDates = (date1, date2) =>
+    Math.ceil(Math.abs(date2.getTime() - date1.getTime()) / (1000 * 3600 * 24) + 1);
 
 const getDatesBetweenTwoDates = (date1, date2) => {
     const currentDate = new Date(date1);
@@ -226,4 +227,4 @@ const getPageCreationDate = async (title) => {
     return new Date(date);
 };
 
-export { getPageViews, getPageRevisionCount, getPageCreationDate };
+export { getPageRevisionCountTimeseries, getPageViewTimeseries, getPageCreationDate };


### PR DESCRIPTION
- Add two functions to format the response to timeseries format. 
- integrate functions with graphs so that we can now show the graph of an article that we are looking at. 

Note: Page view data only dates back to May 2015 by the API. I am not sure yet whether this is a Wikipedia thing or an API thing. What we can do is switch API or fixed the max date of looking back in time to May 2015. We can deal with this in a separate PR.

**I have not connected this with the slider yet**

![image](https://user-images.githubusercontent.com/55929961/201492355-72c0fbe0-63a5-47d8-8240-75be59dc3ca5.png)

Example of API calls:
https://github.com/sukritsangvong/wp-browser-extension/tree/sangvongp/format-timeseries-endpoints#how-to-get-page-count


