### PR TITLE
Add graph slider and helper functions

### DIFF
--- a/wikichange/src/content/content.js
+++ b/wikichange/src/content/content.js
@@ -35,9 +35,9 @@ const renderSlider = (creationDate) => {
     let totalDaysDiff =  (now.getTime() - creationDate.getTime())/(1000 * 3600 * 24);
     let viewsEditsChart = document.getElementById('viewsEditsChart');
     let sliderDiv = document.createElement('div');
-    sliderDiv.innerHTML = `${now.toISOString().slice(0, 10)}  <input type="range" id="graphSlider" value="15" min="0" max="100">  ${creationDate.toISOString().slice(0, 10)}
-                            <br/><output id="output"></output>`;
-    sliderDiv.style.cssText = 'text-align:center;direction: rtl';
+    sliderDiv.innerHTML = `<div style="direction: rtl">${now.toISOString().slice(0, 10)}  <input type="range" id="graphSlider" value="100" min="0" max="100" style="width:60%;">  ${creationDate.toISOString().slice(0, 10)}</div>
+                            <br/><input type="date" value="${creationDate.toISOString().slice(0, 10)}" id="dateOutput" name="dateOutput" style="text-align: center;"> <button onclick="alert('WIP')">Highlight</button><br>`;
+    sliderDiv.style.cssText = 'text-align:center;';
     insertAfter(sliderDiv, viewsEditsChart);
 
     let slider = document.getElementById('graphSlider');
@@ -45,7 +45,7 @@ const renderSlider = (creationDate) => {
         let numDays = parseInt(totalDaysDiff*this.value/100);
         let date = new Date();
         date.setDate(now.getDate() - numDays);
-        document.getElementById('output').innerHTML = date.toISOString().slice(0, 10);
+        document.getElementById('dateOutput').value = date.toISOString().slice(0, 10);
     });
 }
 

--- a/wikichange/src/content/content.js
+++ b/wikichange/src/content/content.js
@@ -29,7 +29,37 @@ const renderGraphOverlay = () => {
     insertAfter(floatContainer, siteSub);
 }
 
+/* Add simple slider to graph. Equivalency between dates and integers: 0: today, 100: creation date */
+const renderSlider = (start) => {
+    let end = new Date();
+    let totalDaysDiff =  (end.getTime() - start.getTime())/(1000 * 3600 * 24);
+    let viewsEditsChart = document.getElementById('viewsEditsChart');
+    let sliderDiv = document.createElement('div');
+    sliderDiv.innerHTML = `${end.toISOString().slice(0, 10)}  <input type="range" id="graphSlider" value="15" min="0" max="100">  ${start.toISOString().slice(0, 10)}
+                            <br/><output id="output"></output>`;
+    sliderDiv.style.cssText = 'text-align:center;direction: rtl';
+    insertAfter(sliderDiv, viewsEditsChart);
+
+    let slider = document.getElementById('graphSlider');
+    slider.addEventListener('change', function (ev) {
+        let numDays = parseInt(totalDaysDiff*this.value/100);
+        var date = new Date();
+        date.setDate(end.getDate() - numDays);
+        document.getElementById('output').innerHTML = date.toISOString().slice(0, 10);
+    });
+}
+
+/* Get the title of a Wikipedia page by inspecting the html */
+const title = (() => {
+    const titleSpan = document.getElementsByClassName('mw-page-title-main');
+    const title = titleSpan[0].innerHTML;
+    return title;
+})();
+
 renderGraphOverlay();
+getPageCreationDate(title).then(function(date) {
+    renderSlider(date);
+});
 
 // Get wikipedia text, global as we shouldn't get it every time we highlight a word 
 let wikiText = document.getElementById('mw-content-text');
@@ -61,13 +91,6 @@ const highlightPersistentContent = (text, color) => {
         'wiki_page_id': wiki_page_id
     });
     return(wiki_page_id);
-})();
-
-/* Get the title of a Wikipedia page by inspecting the html */
-const title = (() => {
-    const titleSpan = document.getElementsByClassName('mw-page-title-main');
-    const title = titleSpan[0].innerHTML;
-    return title;
 })();
 
 const renderDeleteAlert = (count) => {

--- a/wikichange/src/content/content.js
+++ b/wikichange/src/content/content.js
@@ -30,12 +30,12 @@ const renderGraphOverlay = () => {
 }
 
 /* Add simple slider to graph. Equivalency between dates and integers: 0: today, 100: creation date */
-const renderSlider = (start) => {
-    let end = new Date();
-    let totalDaysDiff =  (end.getTime() - start.getTime())/(1000 * 3600 * 24);
+const renderSlider = (creationDate) => {
+    let now = new Date();
+    let totalDaysDiff =  (now.getTime() - creationDate.getTime())/(1000 * 3600 * 24);
     let viewsEditsChart = document.getElementById('viewsEditsChart');
     let sliderDiv = document.createElement('div');
-    sliderDiv.innerHTML = `${end.toISOString().slice(0, 10)}  <input type="range" id="graphSlider" value="15" min="0" max="100">  ${start.toISOString().slice(0, 10)}
+    sliderDiv.innerHTML = `${now.toISOString().slice(0, 10)}  <input type="range" id="graphSlider" value="15" min="0" max="100">  ${creationDate.toISOString().slice(0, 10)}
                             <br/><output id="output"></output>`;
     sliderDiv.style.cssText = 'text-align:center;direction: rtl';
     insertAfter(sliderDiv, viewsEditsChart);
@@ -43,16 +43,16 @@ const renderSlider = (start) => {
     let slider = document.getElementById('graphSlider');
     slider.addEventListener('change', function (ev) {
         let numDays = parseInt(totalDaysDiff*this.value/100);
-        var date = new Date();
-        date.setDate(end.getDate() - numDays);
+        let date = new Date();
+        date.setDate(now.getDate() - numDays);
         document.getElementById('output').innerHTML = date.toISOString().slice(0, 10);
     });
 }
 
 /* Get the title of a Wikipedia page by inspecting the html */
 const title = (() => {
-    const titleSpan = document.getElementsByClassName('mw-page-title-main');
-    const title = titleSpan[0].innerHTML;
+    let titleSpan = document.getElementsByClassName('mw-page-title-main');
+    let title = titleSpan[0].innerHTML;
     return title;
 })();
 

--- a/wikichange/src/content/content.js
+++ b/wikichange/src/content/content.js
@@ -1,5 +1,5 @@
 import { WIKI_CREATION_DATE, AggregateType } from "./enums.js";
-import { getPageViews } from "./timeSeriesService.js";
+import { getPageViews, getPageCreationDate } from "./timeSeriesService.js";
 
 /* Creates the div for the graph overlay. TODO: create the graph and render it here */
 const renderGraphOverlay = () => {
@@ -48,4 +48,11 @@ const pageId = (() => {
         "wiki_page_id": wiki_page_id
     });
     return(wiki_page_id);
+})();
+
+/* Get the title of a Wikipedia page by inspecting the html */
+const title = (() => {
+    const titleSpan = document.getElementsByClassName('mw-page-title-main');
+    const title = titleSpan[0].innerHTML;
+    return title;
 })();

--- a/wikichange/src/content/timeSeriesService.js
+++ b/wikichange/src/content/timeSeriesService.js
@@ -165,7 +165,7 @@ const getPageRevisionCount = async (title, startDate, endDate, aggregateType) =>
     );
     const json = await response.json();
     const date = json.query.pages[Object.keys(json.query.pages)[0]].revisions[0].timestamp;
-    return formatDateToYYYYMMDD(new Date(date));
+    return new Date(date);
 };
 
 export { getPageViews, getPageRevisionCount, getPageCreationDate };

--- a/wikichange/src/content/timeSeriesService.js
+++ b/wikichange/src/content/timeSeriesService.js
@@ -1,6 +1,6 @@
 import { AggregateType } from "./enums.js";
 
-const formatDateToYYYMMDD = (date) =>
+const formatDateToYYYYMMDD = (date) =>
     `${date.getFullYear()}${("0" + (date.getMonth() + 1)).slice(-2)}${("0" + date.getDate()).slice(-2)}`;
 
 const formatYYYYMMDDToDate = (yyyymmdd) =>
@@ -17,8 +17,8 @@ const formatYYYYMMDDToDate = (yyyymmdd) =>
  * @return {map} of an item of an array with properties project, article, granularity(aggregateType), timestamp, access, agent, views
  */
 const fetchPageViews = async (title, startDate, endDate, aggregateType) => {
-    const formattedStartDate = formatDateToYYYMMDD(startDate);
-    const formattedEndDate = formatDateToYYYMMDD(endDate);
+    const formattedStartDate = formatDateToYYYYMMDD(startDate);
+    const formattedEndDate = formatDateToYYYYMMDD(endDate);
     const response = await fetch(
         `https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/en.wikipedia/all-access/all-agents/${title}/${aggregateType}/${formattedStartDate}/${formattedEndDate}`
     );
@@ -153,4 +153,19 @@ const getPageRevisionCount = async (title, startDate, endDate, aggregateType) =>
     }
 };
 
-export { getPageViews, getPageRevisionCount };
+/**
+ * Get the Wikipedia page creation date
+ *
+ * @param {string} title of a wikipedia article
+ * @returns a date in YYYMMDD format
+ */
+ const getPageCreationDate = async (title) => {
+    const response = await fetch(
+        `https://en.wikipedia.org/w/api.php?action=query&prop=revisions&rvlimit=1&rvprop=timestamp&rvdir=newer&titles=${title}&format=json`
+    );
+    const json = await response.json();
+    const date = json.query.pages[Object.keys(json.query.pages)[0]].revisions[0].timestamp;
+    return formatDateToYYYYMMDD(new Date(date));
+};
+
+export { getPageViews, getPageRevisionCount, getPageCreationDate };

--- a/wikichange/src/content/timeSeriesService.js
+++ b/wikichange/src/content/timeSeriesService.js
@@ -157,7 +157,7 @@ const getPageRevisionCount = async (title, startDate, endDate, aggregateType) =>
  * Get the Wikipedia page creation date
  *
  * @param {string} title of a wikipedia article
- * @returns a date in YYYMMDD format
+ * @returns a date in YYYYMMDD format
  */
  const getPageCreationDate = async (title) => {
     const response = await fetch(


### PR DESCRIPTION
Added a simple range slider. On the background it is a 0-100 range, however,  there's an equivalency between dates and integers: 0: today, 100: wiki creation date. For the other dates, its a  percentage of the days between rounded up. For now, there's no interaction between the slider and the graph - I still have to figure this out :)

When you first load the page:

<img width="1459" alt="Captura de Tela 2022-11-10 às 1 52 32 PM" src="https://user-images.githubusercontent.com/36846401/201192793-cc6edbeb-ada8-4243-89f3-01940caf6b4e.png">

Upon changing the slider:
<img width="1456" alt="Captura de Tela 2022-11-10 às 1 52 38 PM" src="https://user-images.githubusercontent.com/36846401/201192823-8cf4e1f1-c2fa-4257-8552-932565f4f0e7.png">

