### PR TITLE
Add addition of paragraph into revision review

### DIFF
--- a/wikichange/src/content/compareRevisionService.js
+++ b/wikichange/src/content/compareRevisionService.js
@@ -11,6 +11,12 @@ const fetchChangeWithHTML = async (startID, endID) => {
         return node.parentElement;
     });
 
+    const allDivs = document.querySelectorAll("div");
+    const divsWithNoInsOuts = [...allDivs].filter((curDiv) => {
+        return curDiv.querySelectorAll("ins.diffchange.diffchange-inline,del.diffchange.diffchange-inline").length == 0;
+    });
+    divsWithNoInsOuts.forEach((x) => console.log(x.innerHTML));
+
     // Removes duplicate divs
     const divsWithIns = divsWithInsWithDuplicate.filter(
         (v, i, a) => a.findIndex((v2) => v2.innerHTML === v.innerHTML) === i
@@ -48,6 +54,10 @@ const fetchChangeWithHTML = async (startID, endID) => {
             highlight = "";
             contentAfter = "";
         }
+    });
+
+    divsWithNoInsOuts.forEach((curDiv) => {
+        addJsonToResultAndReset(result, "", curDiv.innerText, "");
     });
     return result;
 };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/55929961/212559596-6ade267b-d6d4-4577-a4a8-32cc85698e6d.png)
In revision, it turns out that there are two types of adds. An addition that "modify" some words (those with highlights on the right-hand side of the screenshot) and an addition that adds the entire paragraph (those without any highlights but still at the right of the screen). The latter appears a lot in old comparisons where the paragraph changed so much that Wikipedia counts this as an addition to the entire paragraph. Before this, we ignored all this because we thought that it was insignificant. Now, I added those in this pr (add divs that do not contain `ins` or `del`. 

This results in some more highlighting, but we still have to improve the highlight function. In the example, it adds 400 more places to highlight. Ofc, since it is the entire paragraph, there is no `context-before` and `context-after`. We need to adjust our highlights accordingly.

More highlight
![image](https://user-images.githubusercontent.com/55929961/212559743-610a1745-450b-40ec-a1fe-17e6919b8fa5.png)
Some para that got highlighted
![image](https://user-images.githubusercontent.com/55929961/212559764-a59b01c1-35b7-4862-8c4e-670d6d45794a.png)
