### PR TITLE
Change all the values returned that are 0 to null to not show on the graph

### DIFF
--- a/wikichange/src/content/timeSeriesService.js
+++ b/wikichange/src/content/timeSeriesService.js
@@ -21,7 +21,7 @@ const formatResponseToTimeseries = (response, startDate, endDate) => {
     const allDates = getDatesBetweenTwoDates(startDate, endDate);
     return {
         x: allDates.map((date) => date.toLocaleDateString()),
-        y: allDates.map((date) => response.get(date.toLocaleDateString()) ?? 0),
+        y: allDates.map((date) => response.get(date.toLocaleDateString()) ?? null),
     };
 };
 


### PR DESCRIPTION
title. Looks way less crowded. If you only want to do it for just the views and not revisions, let me know.
![image](https://user-images.githubusercontent.com/55929961/213817816-ce2cc244-1f56-4684-9916-1c28ff0aa627.png)
