### PR TITLE
add disable effect and move button styling to centralized css file

### DIFF
--- a/wikichange/assets/content.css
+++ b/wikichange/assets/content.css
@@ -2,3 +2,23 @@ mark{
     background-color: transparent;
     color: inherit;
 }
+
+button {
+    background-color: white;
+    color: #3366CC; 
+    border: 2px solid #3366CC; 
+    cursor: pointer;
+}
+
+button:hover {
+    background-color: #3366CC;
+    color: white;
+  }
+
+button:disabled{
+    cursor: not-allowed;
+    pointer-events: none;
+    border: 2px solid #999999;
+    background-color: #cccccc;
+    color: #999999;
+  }

--- a/wikichange/src/content/content.js
+++ b/wikichange/src/content/content.js
@@ -66,7 +66,7 @@ const renderGraphOverlay = async () => {
         ctx.arc(width / 2, height /2, radius, angle *270, diff / 10 + angle *270, false);
         ctx.stroke();
 
-        if (percentage >= 100) {
+        if (percentage >= 86) {
             clearTimeout(sim);
         } 
         percentage++;
@@ -104,9 +104,9 @@ const renderSlider = async (creationDate) => {
                             <input type="date" value="${initialDate
                                 .toISOString()
                                 .slice(0, 10)}" id="dateOutput" name="dateOutput" style="text-align: center;"> 
-                                <button id = "highlightButton" style="background-color: white; color: #3366CC; border: 2px solid #3366CC; cursor: pointer;">Highlight</button> <div id="loader"></div>
+                                <button id = "highlightButton">Highlight</button> <div id="loader"></div>
                                 <p></p>
-                                <button id = "revisionButton" style="background-color: white; color: #3366CC; border: 2px solid #3366CC; cursor: pointer;">Go To Revision Page</button>
+                                <button id = "revisionButton">Go To Revision Page</button>
                             <div style= "padding-left: 3%; padding-top: 3%; text-align: center;">
                                 <div class="card" style="border-style: solid;">
                                     <div class="card-body" style="text-align: center;">
@@ -154,7 +154,6 @@ const renderSlider = async (creationDate) => {
         oldRevisionId = (await fetchRevisionFromDate(title, date))[0];
 
         // Change the revision context box
-        console.log(getRevisionPageLink(title, curRevisionId, oldRevisionId))
         const revisionDate = document.getElementById("revisionDate");
         revisionDate.innerHTML = `Comparing the current Wikipedia page to the <a href=${getRevisionPageLink(title, curRevisionId, oldRevisionId).replace(/\s/g, "_")} target="_blank">${(await fetchRevisionFromDate(title, date))[1].toLocaleDateString().slice(0, 10)} version</a> (the closest revision to your chosen time)`;
         highlightRevisionBetweenRevisionIds(title, curRevisionId, oldRevisionId);


### PR DESCRIPTION
There is no exact way right now to match the number for now so I put 100 there and try to time it for a medium size page. For now, I will change the number 86% to trick the user into waiting for the load. A more complicated way to do this is I get a finished event from the graph and match that to 100. I am also open to suggestions to draw another thing.

The button is still disabled but the effects are not clear as the old button as the new effect is changing it to a lighter blue. To fix that, I change the button to grey on disabled but my version looks a little bad. 