### PR TITLE
Progress on highlighting p with links

### DIFF
--- a/wikichange/src/content/content.js
+++ b/wikichange/src/content/content.js
@@ -283,7 +283,7 @@ const returnCleanLink = (text_with_link) => {
  *  context and highlight are links. Loops through the DOM tree text nodes, and if no patial
  *  match, checks if it's a link (parent's siblings may contain the needed text)
  *  Note: Walker code idea and sample use (eg.: document.createTreeWalker and walker.nextNode())
- *  is courtesy of ChatGPT
+ *  and the regex /[|=\[\]{}]+|<[^>]*>/g are courtesy of ChatGPT
  *
  * @param {dictionary} context dictionary entry with keys "content_before", "highlight" and "content_after"
  * @param {string} color of the highlight
@@ -302,7 +302,7 @@ const highlightContentUsingNodes = (context, color) => {
     while (walker.nextNode()) {
         textNodes.push(walker.currentNode);
     }
-    let done = true;
+
     let newValue, node, parent;
     textNodes.every((textNode) => {
         node = textNode;
@@ -310,12 +310,12 @@ const highlightContentUsingNodes = (context, color) => {
         let value = node.nodeValue;
         let filter_highlight = context.highlight.replace(/<ref>.*<\/ref>/g, "").replace(/\{\{Cite.*?\}\}/g, "");
         if (context.highlight.includes("[[") && context.highlight.includes("]]")) {
-            // This includes a link in the content it is supposed to highlight
+            // This includes a link in the content it is supposed to highlight. 
+            // Will highlight only first sentence
             newValue = value.replace(
                 filter_highlight,
-                `<mark style='background-color: orange' class='extension-highlight'>${value}</mark>`
+                `<mark style='background-color: ${color}' class='extension-highlight'>${value}</mark>`
             );
-            done = false; // We still need to highlight the rest of the content after the link
         } else {
             newValue = value.replace(
                 filter_highlight,

--- a/wikichange/src/content/content.js
+++ b/wikichange/src/content/content.js
@@ -265,6 +265,19 @@ const highlightContentWithContext = (json, color) => {
 };
 
 /**
+ * Will clean links. Works with links with different and same titles, for instance
+ * [[text]] and [[text|text]] and return the clean version "text"
+ * @param {string} text_with_link
+ */
+const returnCleanLink = (text_with_link) => {
+    let pattern = /\[\[([^\|]+)\|?([^\]]+)\]\]/g;
+    let result = text_with_link.replace(pattern, (_, p1, p2) => {
+        return p2 || p1;
+    });
+    return result;
+}
+
+/**
  *  Highlights the words that are given with context. Support for links,
  *  there are some edge cases that don't work yet (highlight is link + no link) or
  *  context and highlight are links. Loops through the DOM tree text nodes, and if no patial
@@ -289,17 +302,26 @@ const highlightContentUsingNodes = (context, color) => {
     while (walker.nextNode()) {
         textNodes.push(walker.currentNode);
     }
-
+    let done = true;
     let newValue, node, parent;
     textNodes.every((textNode) => {
         node = textNode;
         parent = node.parentNode;
         let value = node.nodeValue;
         let filter_highlight = context.highlight.replace(/<ref>.*<\/ref>/g, "").replace(/\{\{Cite.*?\}\}/g, "");
-        newValue = value.replace(
-            filter_highlight,
-            `<mark style='background-color: ${color}' class='extension-highlight'>${filter_highlight}</mark>`
-        );
+        if (context.highlight.includes("[[") && context.highlight.includes("]]")) {
+            // This includes a link in the content it is supposed to highlight
+            newValue = value.replace(
+                filter_highlight,
+                `<mark style='background-color: orange' class='extension-highlight'>${value}</mark>`
+            );
+            done = false; // We still need to highlight the rest of the content after the link
+        } else {
+            newValue = value.replace(
+                filter_highlight,
+                `<mark style='background-color: ${color}' class='extension-highlight'>${filter_highlight}</mark>`
+            );
+        }
 
         if (newValue !== value) {
             // Clean up the context.content_after and context.content_before from wiki markup


### PR DESCRIPTION
Edit: highlighting the first sentence of the paragraph. Will stop development to focus on tagging highlights. If we have time, will merge another improvement later. Added returnCleanLink function, in case it is useful for anything

Now it highlights the start of a paragraph with links, for example:

![Captura de Tela 2023-01-23 às 7 16 29 PM](https://user-images.githubusercontent.com/36846401/214193202-4508d3bf-4606-441f-8f84-3d1f37554cfb.png)

The highlighted in orage is new highlight, but it should highlight the entire paragraph and not just the first portion. This happens because the current text node ends after "The average class sizes at Carleton is 16 students.", as there is a citation.

Idea: mark as not read, return true after highlighting and then deal with the next node. Problem: when do we know we are truly done? Tried substring of highlighted content (so each time is less, but didn't work).  