### PR TITLE
Fix continuous dot graph

### DIFF
--- a/wikichange/src/content/enums.js
+++ b/wikichange/src/content/enums.js
@@ -1,6 +1,6 @@
 // Values used for timeSeriesService
 const WIKI_CREATION_DATE = new Date("2001-01-15"); // 15 January 2001: to fetch data since creation
-const WIKI_PAGE_VIEW_DATA_AVAILABLE_DATE = new Date("2015-12-01");
+const WIKI_PAGE_VIEW_DATA_AVAILABLE_DATE = new Date("2015-08-01");
 
 const AggregateType = {
     MONTHLY: "monthly",

--- a/wikichange/src/content/enums.js
+++ b/wikichange/src/content/enums.js
@@ -1,9 +1,10 @@
 // Values used for timeSeriesService
 const WIKI_CREATION_DATE = new Date("2001-01-15"); // 15 January 2001: to fetch data since creation
+const WIKI_PAGE_VIEW_DATA_AVAILABLE_DATE = new Date("2015-12-01");
 
 const AggregateType = {
     MONTHLY: "monthly",
     DAILY: "daily",
 };
 
-export { WIKI_CREATION_DATE, AggregateType };
+export { WIKI_CREATION_DATE, WIKI_PAGE_VIEW_DATA_AVAILABLE_DATE, AggregateType };

--- a/wikichange/src/content/timeSeriesService.js
+++ b/wikichange/src/content/timeSeriesService.js
@@ -22,7 +22,7 @@ const isDateWhenPageViewDataBecameAvailable = (isPageViewTimeSeries, date) => {
 };
 
 /**
- * Format data into Chart.js' input format. If the data is a timeseries for page views, it will
+ * Formats data into Chart.js' input format. If the data is a timeseries for page views, it will
  * set all the y values of the dates before the API started collecting page views' data to null
  */
 const formatResponseToTimeseries = (response, startDate, endDate, isPageViewTimeSeries) => {


### PR DESCRIPTION
Instead of replacing all the 0 values to null, only set all 0 before 2016 (when page views data became available) to null.
(https://wikitech.wikimedia.org/wiki/Analytics/AQS/Pageviews)
<img width="1248" alt="image" src="https://user-images.githubusercontent.com/55929961/214754404-4fa440a1-269c-4f80-b286-0e27a66fd0db.png">

Old:
<img width="1039" alt="image" src="https://user-images.githubusercontent.com/55929961/214754293-6ab176eb-8942-4da0-bd19-2a2746003e0a.png">

New: 
<img width="1039" alt="image" src="https://user-images.githubusercontent.com/55929961/214754895-dffbbacc-1dee-4ea4-9917-01448a74025b.png">
