### PR TITLE
Add a small animation when user clicks on graph

### DIFF
--- a/wikichange/assets/content.css
+++ b/wikichange/assets/content.css
@@ -3,7 +3,7 @@ mark {
     color: inherit;
 }
 
-button.extension-button {
+button.extensionButton {
     background-color: white;
     color: #3366cc;
     border: 2px solid #3366cc;
@@ -11,7 +11,7 @@ button.extension-button {
     border-radius: 3px;
 }
 
-button:hover.extension-button {
+button:hover.extensionButton {
     background-color: #3366cc;
     color: white;
 }
@@ -25,7 +25,7 @@ to those of the actual button above
     color: white !important;
 }
 
-button:disabled.extension-button {
+button:disabled.extensionButton {
     cursor: not-allowed;
     pointer-events: none;
     border: 2px solid #999999;

--- a/wikichange/assets/content.css
+++ b/wikichange/assets/content.css
@@ -5,15 +5,14 @@ mark {
 
 button.extension-button {
     background-color: white;
-    color: #3366CC; 
-    border: 2px solid #3366CC; 
+    color: #3366cc;
+    border: 2px solid #3366cc;
     cursor: pointer;
     border-radius: 3px;
-    transition: all 0.3s ease-in-out 0s;
 }
 
 button:hover.extension-button {
-    background-color: #3366CC;
+    background-color: #3366cc;
     color: white;
 }
 
@@ -22,7 +21,7 @@ these hover effect classes should be similar
 to those of the actual button above 
 */
 .buttonHoverEffect {
-    background-color: #3366CC !important;
+    background-color: #3366cc !important;
     color: white !important;
 }
 
@@ -32,4 +31,32 @@ button:disabled.extension-button {
     border: 2px solid #999999;
     background-color: #cccccc;
     color: #999999;
+}
+
+/* wiggle animation from https://codepen.io/jeryj/pen/LzPjdJ */
+.wiggleAnimation {
+    animation: 0.3s wiggle ease;
+}
+
+@keyframes wiggle {
+    0% {
+        transform: rotate(-1.75deg);
+        box-shadow: 0 2px 2px rgba(0, 0, 0, 0.2);
+    }
+    20% {
+        transform: rotate(12deg);
+    }
+    40% {
+        transform: rotate(-6deg);
+    }
+    60% {
+        transform: rotate(4.25deg);
+    }
+    90% {
+        transform: rotate(-1deg);
+    }
+    100% {
+        transform: rotate(0);
+        box-shadow: 0 2px 2px rgba(0, 0, 0, 0.2);
+    }
 }

--- a/wikichange/assets/content.css
+++ b/wikichange/assets/content.css
@@ -3,16 +3,16 @@ mark {
     color: inherit;
 }
 
-button {
+button.extension-button {
     background-color: white;
     color: #3366CC; 
     border: 2px solid #3366CC; 
     cursor: pointer;
-    border-radius: 800px;
+    border-radius: 3px;
     transition: all 0.3s ease-in-out 0s;
 }
 
-button:hover {
+button:hover.extension-button {
     background-color: #3366CC;
     color: white;
 }
@@ -22,11 +22,11 @@ these hover effect classes should be similar
 to those of the actual button above 
 */
 .buttonHoverEffect {
-    background-color: #3366CC;
-    color: white;
+    background-color: #3366CC !important;
+    color: white !important;
 }
 
-button:disabled {
+button:disabled.extension-button {
     cursor: not-allowed;
     pointer-events: none;
     border: 2px solid #999999;

--- a/wikichange/assets/content.css
+++ b/wikichange/assets/content.css
@@ -8,6 +8,8 @@ button {
     color: #3366CC; 
     border: 2px solid #3366CC; 
     cursor: pointer;
+    border-radius: 800px;
+    transition: all 0.3s ease-in-out 0s;
 }
 
 button:hover {

--- a/wikichange/src/content/content.js
+++ b/wikichange/src/content/content.js
@@ -93,6 +93,7 @@ const setUpScaleButton = (scaleButtonsDiv, buttonId, buttonText, duration, scale
     const button = document.createElement("button");
     button.setAttribute("id", buttonId);
     button.setAttribute("style", "margin-right: 5px;");
+    button.setAttribute("class", "extension-button");
     button.innerHTML = buttonText;
     scaleButtonsDiv.appendChild(button);
 
@@ -104,7 +105,7 @@ const setUpScaleButton = (scaleButtonsDiv, buttonId, buttonText, duration, scale
             document.getElementById(input.id).classList.remove("buttonHoverEffect");
         });
 
-        button.className = "buttonHoverEffect";
+        button.classList.add("buttonHoverEffect");
     });
 };
 
@@ -171,9 +172,9 @@ const renderItemsBelowGraph = async (creationDate) => {
     belowGraphDiv.innerHTML = `<input type="date" value="${initialDate
         .toISOString()
         .slice(0, 10)}" id="dateOutput" name="dateOutput" style="text-align: center;"> 
-                                <button id="highlightButton">Highlight</button><div id="loader"></div>
+                                <button class="extension-button" id="highlightButton">Highlight</button><div id="loader"></div>
                                 <p></p>
-                                <button id = "revisionButton">Go To Revision Page</button>
+                                <button class="extension-button" id="revisionButton">Go To Revision Page</button>
                             <div style="padding-left: 3%; padding-top: 3%; text-align: center;">
                                 <div class="card" style="border-style: solid;">
                                     <div class="card-body" style="text-align: center;">

--- a/wikichange/src/content/content.js
+++ b/wikichange/src/content/content.js
@@ -93,7 +93,7 @@ const setUpScaleButton = (scaleButtonsDiv, buttonId, buttonText, duration, scale
     const button = document.createElement("button");
     button.setAttribute("id", buttonId);
     button.setAttribute("style", "margin-right: 5px;");
-    button.setAttribute("class", "extension-button");
+    button.setAttribute("class", "extensionButton");
     button.innerHTML = buttonText;
     scaleButtonsDiv.appendChild(button);
 
@@ -172,9 +172,9 @@ const renderItemsBelowGraph = async (creationDate) => {
     belowGraphDiv.innerHTML = `<input type="date" value="${initialDate
         .toISOString()
         .slice(0, 10)}" id="dateOutput" name="dateOutput" style="text-align: center;"> 
-                                <button class="extension-button" id="highlightButton">Highlight</button><div id="loader"></div>
+                                <button class="extensionButton" id="highlightButton">Highlight</button><div id="loader"></div>
                                 <p></p>
-                                <button class="extension-button" id="revisionButton">Go To Revision Page</button>
+                                <button class="extensionButton" id="revisionButton">Go To Revision Page</button>
                             <div style="padding-left: 3%; padding-top: 3%; text-align: center;">
                                 <div class="card" style="border-style: solid;">
                                     <div class="card-body" style="text-align: center;">

--- a/wikichange/src/content/content.js
+++ b/wikichange/src/content/content.js
@@ -119,7 +119,7 @@ const renderSlider = async (creationDate) => {
                             <input type="date" value="${initialDate
                                 .toISOString()
                                 .slice(0, 10)}" id="dateOutput" name="dateOutput" style="text-align: center;"> 
-                                <button id = "highlightButton">Highlight</button> <div id="loader"></div>
+                                <button id="highlightButton">Highlight</button><div id="loader"></div>
                                 <p></p>
                                 <button id = "revisionButton">Go To Revision Page</button>
                             <div style="padding-left: 3%; padding-top: 3%; text-align: center;">

--- a/wikichange/src/content/graph.js
+++ b/wikichange/src/content/graph.js
@@ -79,13 +79,12 @@ const makePageViewAndReivisionGraphFromData = (pageViewsData, revisionsData) => 
         type: "line",
         data: data,
         options: {
-            onClick: () => {
+            onClick: (e) => {
                 const date = e.chart.tooltip.dataPoints[0].label;
                 updateDateSelector(date);
                 const highlightButton = document.getElementById("highlightButton");
-                let original_font = highlightButton.style.fontSize;
                 highlightButton.style.fontSize = "130%";
-                delay(1000).then(() => highlightButton.style.fontSize = original_font);
+                delay(500).then(() => highlightButton.style.fontSize = "100%");
             },
             plugins: {
                 tooltip: {

--- a/wikichange/src/content/graph.js
+++ b/wikichange/src/content/graph.js
@@ -12,6 +12,15 @@ const CHART_COLORS = {
 };
 
 /**
+ * 
+ * @param {*} time in milliseconds
+ * @returns a promise that will delay
+ */
+const delay = (time) => {
+    return new Promise(resolve => setTimeout(resolve, time));
+}
+
+/**
  * Injects a graph of a given article's page views and edits data.
  *
  * @param {string} title of the article
@@ -71,6 +80,12 @@ const injectGraphToPage = async (title, startDate, endDate) => {
         type: "line",
         data: data,
         options: {
+            onClick: () => {
+                const highlightButton = document.getElementById("highlightButton");
+                let original_font = highlightButton.style.fontSize;
+                highlightButton.style.fontSize = "130%";
+                delay(1000).then(() => highlightButton.style.fontSize = original_font);
+            },
             plugins: {
                 tooltip: {
                     position: "nearest",

--- a/wikichange/src/content/graph.js
+++ b/wikichange/src/content/graph.js
@@ -12,13 +12,13 @@ const CHART_COLORS = {
 };
 
 /**
- * 
+ *
  * @param {*} time in milliseconds
  * @returns a promise that will delay
  */
 const delay = (time) => {
-    return new Promise(resolve => setTimeout(resolve, time));
-}
+    return new Promise((resolve) => setTimeout(resolve, time));
+};
 
 let pageViews = null;
 let revisions = null;
@@ -83,8 +83,8 @@ const makePageViewAndReivisionGraphFromData = (pageViewsData, revisionsData) => 
                 const date = e.chart.tooltip.dataPoints[0].label;
                 updateDateSelector(date);
                 const highlightButton = document.getElementById("highlightButton");
-                highlightButton.style.fontSize = "130%";
-                delay(500).then(() => highlightButton.style.fontSize = "100%");
+                highlightButton.classList.add("wiggleAnimation");
+                delay(500).then(() => highlightButton.classList.remove("wiggleAnimation"));
             },
             plugins: {
                 tooltip: {


### PR DESCRIPTION
When the user clicks on the graph the highlight button will get larger. Made the buttons round (I think it makes them more evident)

<img width="1003" alt="Captura de Tela 2023-01-28 às 3 05 15 PM" src="https://user-images.githubusercontent.com/36846401/215291064-0b70c0cb-9566-43ee-b1ea-4c48cddaca21.png">

