### PR TITLE
Make fetch Revisions parallel

### DIFF
--- a/wikichange/src/content/content.js
+++ b/wikichange/src/content/content.js
@@ -2,7 +2,7 @@ import { getPageCreationDate } from "./timeSeriesService.js";
 import { injectGraphToPage, injectScaledCurrentGraphToPage } from "./graph.js";
 import { fetchChangeWithHTML, fetchRevisionFromDate, getRevisionPageLink } from "./compareRevisionService.js";
 import { HighlightType, HIGHLIGHT_TYPE } from "./enums";
-import { markContent  } from "./markContent.js";
+import { markContent } from "./markContent.js";
 
 /**
  * Inserts a new node after an existing node
@@ -526,7 +526,6 @@ const highlightRevisionBetweenRevisionIds = async (title, curRevisionId, oldRevi
     }
 };
 
-
 /**
  * Highlight a page by comparing two revisions
  *
@@ -538,8 +537,8 @@ const highlight = async (revisionId, oldRevisionId) => {
     if (HIGHLIGHT_TYPE == HighlightType.NODE) {
         const succeed = [];
         const fail = [];
-        for(let element of arr){
-            if(highlightContentUsingNodes(element, "#AFE1AF")){
+        for (let element of arr) {
+            if (highlightContentUsingNodes(element, "#AFE1AF")) {
                 succeed.push(element);
             } else {
                 fail.push(element);

--- a/wikichange/src/content/timeSeriesService.js
+++ b/wikichange/src/content/timeSeriesService.js
@@ -80,7 +80,6 @@ const fetchPageRevisionsParallel = async (title, startDate, endDate, numPartitio
 
     return Promise.all(promises)
         .then((results) => results.reduce((acc, res) => acc.concat(res), []))
-        .then((combinedResults) => combinedResults)
         .catch((error) =>
             console.error(
                 `$Error parallel fetching revisions for title:${title} startDate:${startDate} endDate:${endDate} \nErrror:${error}`


### PR DESCRIPTION
Made `fetchPageRevisions` parallel by partitioning the given date ranges into partitions and calling fetch revisions on each of them "at the same time". Checked the output and they produce the same output as the non-parallel version.

Added the timer and found that this improved getRevision speed by almost 4 times. Can do more investigation on what is the right number of partitions later.