### PR TITLE
Disable scale buttons on small pages

### DIFF
--- a/wikichange/src/content/content.js
+++ b/wikichange/src/content/content.js
@@ -176,7 +176,14 @@ const renderItemsBelowGraph = async (creationDate) => {
     let belowGraphDiv = document.createElement("div");
     belowGraphDiv.setAttribute("id", "belowGraphDiv");
     let initialDate = new Date();
-    initialDate.setDate(now.getDate() - totalDaysDiff * 0.5);
+    console.log(totalDaysDiff);
+
+    // set to half on small page, else set to 2.5 years
+    if (totalDaysDiff < 365 * 5) {
+        initialDate.setDate(now.getDate() - totalDaysDiff * 0.5);
+    } else {
+        initialDate.setDate(now.getDate() - 365 * 2.5);
+    }
 
     let curRevisionId = (await fetchRevisionFromDate(title, now))[0];
     const oldRevision = await fetchRevisionFromDate(title, initialDate);

--- a/wikichange/src/content/content.js
+++ b/wikichange/src/content/content.js
@@ -192,7 +192,6 @@ const renderItemsBelowGraph = async (creationDate) => {
     let belowGraphDiv = document.createElement("div");
     belowGraphDiv.setAttribute("id", "belowGraphDiv");
     let initialDate = new Date();
-    console.log(totalDaysDiff);
 
     // set to half on small page, else set to 2.5 years
     if (totalDaysDiff < 365 * 5) {

--- a/wikichange/src/content/content.js
+++ b/wikichange/src/content/content.js
@@ -89,16 +89,17 @@ const renderGraphOverlay = async () => {
         document.getElementById("5y").click();
     });
 
-    renderScaleButtons();
+    renderScaleButtons(creationDate);
     return graphPromise; // Promise of whether the graph is injected
 };
 
-const setUpScaleButton = (scaleButtonsDiv, buttonId, buttonText, duration, scaleButtonInputs) => {
+const setUpScaleButton = (scaleButtonsDiv, buttonId, buttonText, duration, scaleButtonInputs, isDisable) => {
     const button = document.createElement("button");
     button.setAttribute("id", buttonId);
     button.setAttribute("style", "margin-right: 5px;");
     button.setAttribute("class", "extensionButton");
     button.innerHTML = buttonText;
+    button.disabled = isDisable;
     scaleButtonsDiv.appendChild(button);
 
     button.addEventListener("click", () => {
@@ -113,22 +114,33 @@ const setUpScaleButton = (scaleButtonsDiv, buttonId, buttonText, duration, scale
     });
 };
 
-const setUpScaleButtons = (scaleButtonsDiv, scaleButtonInputs) => {
-    scaleButtonInputs.forEach((input) => {
-        setUpScaleButton(scaleButtonsDiv, input.id, input.name, input.duration, scaleButtonInputs);
-    });
-};
-
 const getDateObjectFromNow = (monthsFromCurrent) => {
+    if (monthsFromCurrent == null) {
+        return null;
+    }
     const date = new Date();
     date.setMonth(date.getMonth() - monthsFromCurrent);
     return date;
 };
 
+const setUpScaleButtons = (scaleButtonsDiv, scaleButtonInputs, creationDate) => {
+    const pageAgeInMonths = (new Date().getTime() - creationDate.getTime()) / (1000 * 3600 * 24 * 30);
+    scaleButtonInputs.forEach((input) => {
+        setUpScaleButton(
+            scaleButtonsDiv,
+            input.id,
+            input.name,
+            getDateObjectFromNow(input.duration),
+            scaleButtonInputs,
+            input.duration && pageAgeInMonths < input.duration
+        );
+    });
+};
+
 /**
  * Render buttons to scale the graph.
  */
-const renderScaleButtons = () => {
+const renderScaleButtons = (creationDate) => {
     const viewsEditsChart = document.getElementById("viewsEditsChart");
     const scaleButtonsDiv = document.createElement("div");
     scaleButtonsDiv.setAttribute("id", "scaleButtonsDiv");
@@ -136,14 +148,14 @@ const renderScaleButtons = () => {
 
     const scaleButtonInputs = [
         { id: "all", name: "ALL", duration: null }, // null represents shows everything
-        { id: "5y", name: "5Y", duration: getDateObjectFromNow(5 * 12) },
-        { id: "3y", name: "3Y", duration: getDateObjectFromNow(3 * 12) },
-        { id: "1y", name: "1Y", duration: getDateObjectFromNow(12) },
-        { id: "6m", name: "6M", duration: getDateObjectFromNow(6) },
-        { id: "3m", name: "3M", duration: getDateObjectFromNow(3) },
+        { id: "5y", name: "5Y", duration: 5 * 12 },
+        { id: "3y", name: "3Y", duration: 3 * 12 },
+        { id: "1y", name: "1Y", duration: 12 },
+        { id: "6m", name: "6M", duration: 6 },
+        { id: "3m", name: "3M", duration: 3 },
     ];
 
-    setUpScaleButtons(scaleButtonsDiv, scaleButtonInputs);
+    setUpScaleButtons(scaleButtonsDiv, scaleButtonInputs, creationDate);
 
     // inserts buttons above graph
     viewsEditsChart.parentNode.insertBefore(scaleButtonsDiv, viewsEditsChart);

--- a/wikichange/src/content/content.js
+++ b/wikichange/src/content/content.js
@@ -86,7 +86,11 @@ const renderGraphOverlay = async () => {
     const sim = setInterval(progressBar, 3);
 
     const graphPromise = injectGraphToPage(title, creationDate, new Date(Date.now())).then(async () => {
-        document.getElementById("5y").click();
+        if (document.getElementById("5y").disabled) {
+            document.getElementById("all").click();
+        } else {
+            document.getElementById("5y").click();
+        }
     });
 
     renderScaleButtons(creationDate);


### PR DESCRIPTION
- Disable scale buttons on small pages
- Make the default date 2.5 years, but if the page is newer than that, will take the middle as usual
(The graph loads very slowly because there is a lot of info for most of these new topics. i.e. Russian Ukraine invasion has  more than 500 edits per day for about a week)

![image](https://user-images.githubusercontent.com/55929961/216786859-b63cfe92-d611-4026-9c70-63ba76495ff9.png)
