### PR TITLE
Fix problem with context before after for highlight getting switched

### DIFF
--- a/wikichange/src/content/compareRevisionService.js
+++ b/wikichange/src/content/compareRevisionService.js
@@ -22,9 +22,9 @@ const fetchChangeWithHTML = async (startID, endID) => {
     );
 
     // Construct result array of maps
-    let contentBefore = "";
-    let highlight = "";
-    let contentAfter = "";
+    let contentBefore = null;
+    let highlight = null;
+    let contentAfter = null;
     const result = [];
     divsWithIns.forEach((element) => {
         element.childNodes.forEach((child) => {
@@ -32,26 +32,30 @@ const fetchChangeWithHTML = async (startID, endID) => {
             const content = child.textContent.replaceAll(/(<ref.*?>.*?<\/ref>)/g, "");
 
             if (nodeName == "#text") {
-                if (contentBefore == "") {
+                if (highlight == null && contentBefore == null) {
                     contentBefore = content;
                 } else {
                     contentAfter = content;
 
                     addJsonToResultAndReset(result, contentBefore, highlight, contentAfter);
-                    contentBefore = "";
-                    highlight = "";
-                    contentAfter = "";
+                    contentBefore = null;
+                    highlight = null;
+                    contentAfter = null;
                 }
             } else if (nodeName == "INS") {
-                highlight += ` ${content}`;
+                if (highlight == null) {
+                    highlight = content;
+                } else {
+                    highlight += ` ${content}`;
+                }
             }
         });
 
-        if (contentBefore != "" || highlight || ("" && contentAfter) || "") {
+        if (contentBefore != null || highlight || contentAfter != null) {
             addJsonToResultAndReset(result, contentBefore, highlight, contentAfter);
-            contentBefore = "";
-            highlight = "";
-            contentAfter = "";
+            contentBefore = null;
+            highlight = null;
+            contentAfter = null;
         }
     });
 
@@ -63,9 +67,9 @@ const fetchChangeWithHTML = async (startID, endID) => {
 
 const addJsonToResultAndReset = (result, contentBefore, highlight, contentAfter) => {
     result.push({
-        content_before: contentBefore,
+        content_before: contentBefore == null ? "" : contentBefore,
         highlight: highlight,
-        content_after: contentAfter,
+        content_after: contentAfter == null ? "" : contentAfter,
     });
 };
 


### PR DESCRIPTION
- the initial algorithm doesn't check for current highlights before assigning context before and after. now use `null` instead of an empty string to avoid problems when comparing with actual empty strings. 
Before
```
{
        "content_before": "Most dried pasta is produced",
        "highlight": "Pastas are divided into two broad categories: dried ({{lang|it|pasta secca}}) and fresh ({{lang|it|pasta fresca}}).   commercially",
        "content_after": " via an [["
    },
```
After
```
{
        "content_before": "",
        "highlight": "Pastas are divided into two broad categories: dried ({{lang|it|pasta secca}}) and fresh ({{lang|it|pasta fresca}}).",
        "content_after": "Most dried pasta is produced"
    },
```
What it is supposed to be.
<img width="1106" alt="image" src="https://user-images.githubusercontent.com/55929961/216790932-9bac1c79-71f4-47fe-9a77-e08c5a11481f.png">

Can see some improvements in number of highlights from the fix.
