### PR TITLE
Change the way to construct diff from html

### DIFF
--- a/wikichange/src/content/compareRevisionService.js
+++ b/wikichange/src/content/compareRevisionService.js
@@ -51,7 +51,7 @@ const fetchChangeWithHTML = async (startID, endID) => {
  * @returns cleaned up content that has no {{...}} and <ref>...</ref>
  */
 const cleanUpContent = (content) => {
-    return content.replace(/{{.*?}}|<ref.*?<\/ref>|\[\[|\]\]/g, "").replace(/<ref>.*$|.*$<\/ref>/g, "");
+    return content.replace(/{{.*?}}|<ref.*?<\/ref>/g, "").replace(/<ref>.*$|.*$<\/ref>/g, "");
 };
 
 const isOnlyContainsSymbols = (text) => /^[\W\s]+$/.test(text);

--- a/wikichange/src/content/compareRevisionService.js
+++ b/wikichange/src/content/compareRevisionService.js
@@ -48,7 +48,7 @@ const fetchChangeWithHTML = async (startID, endID) => {
 
 /**
  * @param {string} content
- * @returns cleaned up content that has no {{...}} and <ref>...</ref>
+ * @returns cleaned up content that has no {{...}}, <ref>...</ref>, <ref>..., and ...</ref>
  */
 const cleanUpContent = (content) => {
     return content.replace(/{{.*?}}|<ref.*?<\/ref>/g, "").replace(/<ref>.*$|.*$<\/ref>/g, "");


### PR DESCRIPTION
- the diff includes more context before and after
- Remove some basic unnecessary stuff like things in between `<ref>` and `</ref>`, things between `{{` and `}}`, things after `<ref>`, and things before `</ref>`. (the last two things are for when ref tags get cut off in the middle of the tags.
Before:
```
{
        "content_before": "",
        "highlight": "sheets",
        "content_after": " of dough,{{sfn|Serventi|Sabban|2002|pages=15–16}} and "
    },
    {
        "content_before": "",
        "highlight": "gave",
        "content_after": " rise to"
    },
    {
        "content_before": "",
        "highlight": "the",
        "content_after": " Italian "
    },
```
Now:
```
 {
        "content_before": ", which in Latin refers to thin ",
        "highlight": "sheets",
        "content_after": " of dough, and "
    },
    {
        "content_before": " of dough, and ",
        "highlight": "gave",
        "content_after": " rise to"
    },
    {
        "content_before": " rise to",
        "highlight": "the",
        "content_after": " Italian "
    },
```

<img width="1060" alt="image" src="https://user-images.githubusercontent.com/55929961/216792581-3afe3c49-f0b3-401f-969e-01c58e768b33.png">

Problem: 
I can see cases where the highlight is highlighting something that is not supposed to be highlighted (doesn't seem to look at the context before and after)
<img width="720" alt="image" src="https://user-images.githubusercontent.com/55929961/216792697-bbe54fbd-f7d3-4a54-aa37-bbdaf09d3fd2.png">
even though it has 
```
{
        "content_before": ", which in Latin refers to thin ",
        "highlight": "sheets",
        "content_after": " of dough, and "
    },
```

