### PR TITLE
Node highlight improvements

### DIFF
--- a/wikichange/src/content/cleanText.js
+++ b/wikichange/src/content/cleanText.js
@@ -28,7 +28,8 @@ const cleanText = (context) => {
                  .replace(/\{\{Cite.*?\}\}/g, "")
                  .replace(/cite web/g, "")
                  .replace(/=/g, "")
-                 .replace(/{{/g, "").replace(/}}/g, "");
+                 .replace(/{{/g, "").replace(/}}/g, "")
+                 .replace(/'(.*?)'/g, "");
             context[type] = clean;
         }
     }

--- a/wikichange/src/content/content.js
+++ b/wikichange/src/content/content.js
@@ -476,6 +476,12 @@ const highlightRevisionBetweenRevisionIds = async (title, curRevisionId, oldRevi
     }
 };
 
+/**
+ * If there's a link in the text to highlight, it will split and update the context after and before
+ * 
+ * @param {dictionary} element dictionary entry with keys "content_before", "highlight" and "content_after"
+ * @returns an array of dictionaries 
+ */
 const splitElementNode = (element) => {
     let result = [];
     if (element.highlight.includes("[[") && element.highlight.includes("]]")) {
@@ -514,7 +520,6 @@ const highlight = async (revisionId, oldRevisionId) => {
                 }
             }
         }
-        console.log(fail);
     } else {
         markContent(arr, "#AFE1AF").then(({ succeed, fail }) => {});
     }

--- a/wikichange/src/content/content.js
+++ b/wikichange/src/content/content.js
@@ -381,21 +381,11 @@ const highlightContentUsingNodes = (context, color) => {
         node = textNode;
         parent = node.parentNode;
         let value = node.nodeValue;
-        let filter_highlight = context.highlight.replace(/<ref>.*<\/ref>/g, "").replace(/\{\{Cite.*?\}\}/g, "");
-        if (context.highlight.includes("[[") && context.highlight.includes("]]")) {
-            // This includes a link in the content it is supposed to highlight.
-            // Will highlight only first sentence
-            newValue = value.replace(
-                filter_highlight,
-                `<mark style='background-color: ${color}' class='extension-highlight'>${value}</mark>`
-            );
-        } else {
-            newValue = value.replace(
-                filter_highlight,
-                `<mark style='background-color: ${color}' class='extension-highlight'>${filter_highlight}</mark>`
-            );
-        }
-
+        let filter_highlight = context.highlight.replace(/<ref>.*<\/ref>/g, "").replace(/\{\{Cite.*?\}\}/g, ""); 
+        newValue = value.replace(
+            filter_highlight,
+            `<mark style='background-color: ${color}' class='extension-highlight'>${filter_highlight}</mark>`
+        );
         if (newValue !== value) {
             // Clean up the context.content_after and context.content_before from wiki markup
             let content_after = context.content_after.replace(/[|=\[\]{}]+|<[^>]*>/g, "").replace("cite web", "");
@@ -486,6 +476,22 @@ const highlightRevisionBetweenRevisionIds = async (title, curRevisionId, oldRevi
     }
 };
 
+const splitElementNode = (element) => {
+    let result = [];
+    if (element.highlight.includes("[[") && element.highlight.includes("]]")) {
+        let split = element.highlight.split(/\[\[(.*?)\]\]/);
+        for (let i = 0; i < split.length; i++) {
+            result.push({
+                content_before: i != 0 ? split[i-1] : "",
+                highlight: split[i],
+                content_after: i != (split.length-1) ? split[i+1] : "",
+            });
+        }
+        return result;
+    }
+    return [element];
+};
+
 /**
  * Highlight a page by comparing two revisions
  *
@@ -497,14 +503,18 @@ const highlight = async (revisionId, oldRevisionId) => {
     if (HIGHLIGHT_TYPE == HighlightType.NODE) {
         const succeed = [];
         const fail = [];
-        for(let element of arr){
-            element = cleanText(element);
-            if(highlightContentUsingNodes(element, "#AFE1AF")){
-                succeed.push(element);
-            } else {
-                fail.push(element);
+        for(let element of arr) {
+            let splitElement = splitElementNode(element);
+            for (let subElement of splitElement) {
+                subElement = cleanText(subElement);
+                if (highlightContentUsingNodes(subElement, "#AFE1AF")) {
+                    succeed.push(subElement);
+                } else {
+                    fail.push(subElement);
+                }
             }
         }
+        console.log(fail);
     } else {
         markContent(arr, "#AFE1AF").then(({ succeed, fail }) => {});
     }


### PR DESCRIPTION
Split the nodes if there's a link in the thing to highlight. Also update context. 

MAIN (BEFORE):

- Tagging char (slow):
<img width="1050" alt="Captura de Tela 2023-02-05 às 1 27 10 PM" src="https://user-images.githubusercontent.com/36846401/216840511-942ed019-a809-4a0b-8857-02560ecf130b.png">

- Node
<img width="1351" alt="Captura de Tela 2023-02-05 às 1 27 35 PM" src="https://user-images.githubusercontent.com/36846401/216840518-5fcdc2cb-3cef-4f95-8de9-ad4efdbee42f.png">


THIS BRANCH (AFTER):

- Node
<img width="1009" alt="Captura de Tela 2023-02-05 às 1 26 48 PM" src="https://user-images.githubusercontent.com/36846401/216840494-ae249c42-c384-4339-92e4-19709cf0452c.png">
