### PR TITLE
Luisae/highlight accuracy

### DIFF
--- a/wikichange/src/content/content.js
+++ b/wikichange/src/content/content.js
@@ -379,7 +379,7 @@ const highlightContentUsingNodes = (context, color) => {
             // Clean up the context.content_after and context.content_before from wiki markup
             let content_after = context.content_after.replace(/[|=\[\]{}]+|<[^>]*>/g, "").replace("cite web", "");
             let content_before = context.content_before.replace(/[|=\[\]{}]+|<[^>]*>/g, "").replace("cite web", "");
-            if (value.includes(content_after) || value.includes(content_before)) {
+            if (value.includes(content_after) && value.includes(content_before)) {
                 // Or because of edge cases, if good context this will almost always work
                 let newNode = document.createElement("span");
                 newNode.innerHTML = newValue;
@@ -394,7 +394,7 @@ const highlightContentUsingNodes = (context, color) => {
                     node.parentNode.nextSibling.nodeValue != null &&
                     node.parentNode.previousSibling != null &&
                     node.parentNode.previousSibling.nodeValue != null &&
-                    (node.parentNode.nextSibling.nodeValue.includes(content_after) ||
+                    (node.parentNode.nextSibling.nodeValue.includes(content_after) &&
                         node.parentNode.previousSibling.nodeValue.includes(content_before))
                 ) {
                     let newNode = document.createElement("span");

--- a/wikichange/src/manifest.json
+++ b/wikichange/src/manifest.json
@@ -41,5 +41,8 @@
                 "assets/content.css"
             ]
 		}
-	]
+	],
+    "content_security_policy": {
+        "extension_pages": "script-src 'self'; object-src 'self'; script-src-elem 'self' 'unsafe-inline' https://cdn.jsdelivr.net;"
+    }
 }

--- a/wikichange/src/popup/popup.html
+++ b/wikichange/src/popup/popup.html
@@ -5,9 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
-    <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.12.9/dist/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
     <title>WikiExtension</title>
   </head>
   <body>


### PR DESCRIPTION
Note: this change will highlight less, but more accurately. It will also slow the page a little bit but nothing noticeably in my computer :) 

1) In node: made all if statements match both content after AND content before (instead of OR). 
2) In Tagging/word include a function that chooses our index instead of using the first. This also matches both contexts
3) Fix an unrelated security error when opening the popup 