### PR TITLE
Make get title ignore #

### DIFF
--- a/wikichange/src/content/globals.js
+++ b/wikichange/src/content/globals.js
@@ -35,15 +35,16 @@ const page_id = (() => {
  * @returns a string with title of a page
  */
 const title = (() => {
-    let alternate_title = document.getElementById("firstHeading").innerText;
+    const alternate_title = document.getElementById("firstHeading").innerText;
     debug_console?.info(alternate_title);
     if (alternate_title.length !== 0) {
         return alternate_title;
     }
-    let titleSpan = document.getElementsByClassName("mw-page-title-main");
+
+    const titleSpan = document.getElementsByClassName("mw-page-title-main");
     if (titleSpan.length === 0) {
-        let url = document.URL.split("/");
-        return url[url.length - 1].replace("_", " ");
+        const titleFromUrl = document.URL.match(/^https?:\/\/[^/]+\/[^/]+\/([^/?#]*)/i)[1].replace("_", " ");
+        return titleFromUrl;
     } else {
         return titleSpan[0].innerHTML;
     }


### PR DESCRIPTION
What @RichartE added for the alternate title is good enough, but in case that doesn't work, the "getting title from URL" portion would be parsing out `Death Note#Production` for URL like this https://en.wikipedia.org/wiki/Death_Note#Production. The changes in this pr stop that from happening.