### PR TITLE
Comments, duplicate regex and enhancement

### DIFF
--- a/wikichange/src/content/enums.js
+++ b/wikichange/src/content/enums.js
@@ -23,8 +23,10 @@ chrome.storage.sync.get({
     document.head.append(stylesheet);
 }); 
 
+// No console.logs when we are not testing
 const DEBUG = false;
 
+// Set the default tagging method
 const HIGHLIGHT_TYPE = HighlightType.TAGGING_CHAR;
 
 export { WIKI_CREATION_DATE, WIKI_PAGE_VIEW_DATA_AVAILABLE_DATE, AggregateType, HIGHLIGHT_TYPE, HighlightType, DEBUG };

--- a/wikichange/src/content/markPageChar.js
+++ b/wikichange/src/content/markPageChar.js
@@ -3,6 +3,7 @@ document.head.append(stylesheet);
 
 let toMark = '';
 let toStyle = '';
+
 /**
  * Keep track in characters to highlight
  * @param {int} start of the indexes to highlight

--- a/wikichange/src/content/markPageWord.js
+++ b/wikichange/src/content/markPageWord.js
@@ -5,6 +5,7 @@ document.head.append(stylesheet);
 
 let toMark = '';
 let toStyle = '';
+
 /**
  * Add a highlight over an index range
  * @param {int} start of the indexes to highlight

--- a/wikichange/src/content/tagEveryWord.js
+++ b/wikichange/src/content/tagEveryWord.js
@@ -11,10 +11,12 @@ const tagEveryWord = () => {
             if (node.parentElement.tagName === 'STYLE') {
                 return NodeFilter.FILTER_REJECT;
             }
-            // Skip the references
+
+            // Skip the references, the code is fast so no need to do so
             // if (node.parentElement.closest('.reflist')){
             //     return NodeFilter.FILTER_REJECT;
             // }
+            
             if (node.nodeValue.trim()){
                 return NodeFilter.FILTER_ACCEPT;
             } 


### PR DESCRIPTION
- Remove duplicate cleanings: There were some matchings that we were doing 3 times (for example, removing ``<refs>`` or {{), so I removed some replace code.
- Now we highlight lists 
<img width="358" alt="Captura de Tela 2023-03-04 às 12 42 41 PM" src="https://user-images.githubusercontent.com/36846401/222923331-64863213-da31-4f83-a7be-5ccbea23662f.png">
- In split node I was just considering the simple link, so I changed to consider both [[extra|link]] and [[link]]. More is highlighted. I realized this issue while taking screenshots for the slides. 
- Added and edited some comments, clarified what some regex was doing. 

Before:
<img width="973" alt="Captura de Tela 2023-03-04 às 12 45 38 PM" src="https://user-images.githubusercontent.com/36846401/222923451-89162c4e-64a6-4a08-a303-41f174da6a9a.png">

Now:
<img width="993" alt="Captura de Tela 2023-03-04 às 12 45 23 PM" src="https://user-images.githubusercontent.com/36846401/222923454-9e2ecc4a-8d6e-4b80-8606-4ce9dbfaec47.png">
